### PR TITLE
feat: implement clue management system

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -18,6 +18,8 @@ pub enum HuntErrorCode {
     InvalidTitle = 11,
     InvalidDescription = 12,
     InvalidAddress = 13,
+    TooManyClues = 14,
+    InvalidQuestion = 15,
 }
 
 #[derive(Debug)]
@@ -35,6 +37,8 @@ pub enum HuntError {
     InvalidTitle { reason: String },
     InvalidDescription { reason: String },
     InvalidAddress,
+    TooManyClues { hunt_id: u64, limit: u32 },
+    InvalidQuestion,
 }
 
 impl fmt::Display for HuntError {
@@ -79,27 +83,34 @@ impl fmt::Display for HuntError {
             HuntError::InvalidAddress => {
                 write!(f, "Invalid address")
             }
+            HuntError::TooManyClues { hunt_id, limit } => {
+                write!(f, "Too many clues for hunt {} (limit {})", hunt_id, limit)
+            }
+            HuntError::InvalidQuestion => {
+                write!(f, "Invalid question (empty or exceeds max length)")
+            }
         }
     }
 }
-
 
 impl From<HuntError> for HuntErrorCode {
     fn from(err: HuntError) -> Self {
         match err {
             HuntError::HuntNotFound { .. } => HuntErrorCode::HuntNotFound,
             HuntError::ClueNotFound { .. } => HuntErrorCode::ClueNotFound,
-            HuntError::InvalidHuntStatus { .. } => HuntErrorCode::InvalidHuntStatus,
+            HuntError::InvalidHuntStatus => HuntErrorCode::InvalidHuntStatus,
             HuntError::PlayerNotRegistered { .. } => HuntErrorCode::PlayerNotRegistered,
             HuntError::ClueAlreadyCompleted { .. } => HuntErrorCode::ClueAlreadyCompleted,
-            HuntError::InvalidAnswer { .. } => HuntErrorCode::InvalidAnswer,
+            HuntError::InvalidAnswer => HuntErrorCode::InvalidAnswer,
             HuntError::HuntNotActive { .. } => HuntErrorCode::HuntNotActive,
-            HuntError::Unauthorized { .. } => HuntErrorCode::Unauthorized,
+            HuntError::Unauthorized => HuntErrorCode::Unauthorized,
             HuntError::InsufficientRewardPool { .. } => HuntErrorCode::InsufficientRewardPool,
             HuntError::DuplicateRegistration { .. } => HuntErrorCode::DuplicateRegistration,
             HuntError::InvalidTitle { .. } => HuntErrorCode::InvalidTitle,
             HuntError::InvalidDescription { .. } => HuntErrorCode::InvalidDescription,
-            HuntError::InvalidAddress { .. } => HuntErrorCode::InvalidAddress,
+            HuntError::InvalidAddress => HuntErrorCode::InvalidAddress,
+            HuntError::TooManyClues { .. } => HuntErrorCode::TooManyClues,
+            HuntError::InvalidQuestion => HuntErrorCode::InvalidQuestion,
         }
     }
 }

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String, Vec, Env};
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec, Env};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,17 +35,25 @@ pub struct Hunt {
     pub required_clues: u32,
 }
 
+/// Stored clue with SHA256 answer hash. The hash is never exposed via get_clue/list_clues or events.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Clue {
     pub clue_id: u32,
     pub question: String,
-    pub answer_hash: String, 
+    pub answer_hash: BytesN<32>,
     pub points: u32,
     pub is_required: bool,
-    pub hint: String, 
-    pub has_location: bool,
-    pub location: Location,
+}
+
+/// Clue info returned by get_clue/list_clues. Excludes answer hash.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClueInfo {
+    pub clue_id: u32,
+    pub question: String,
+    pub points: u32,
+    pub is_required: bool,
 }
 
 #[contracttype]
@@ -188,4 +196,16 @@ pub struct RewardClaimedEvent {
     pub player: Address,
     pub xlm_amount: i128,
     pub nft_awarded: bool,
+}
+
+/// Emitted when a clue is added. Does not expose the answer hash.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ClueAddedEvent {
+    pub hunt_id: u64,
+    pub clue_id: u32,
+    pub creator: Address,
+    pub question: String,
+    pub points: u32,
+    pub is_required: bool,
 }


### PR DESCRIPTION
# Summary of Changes – Clue Management System
This PR Closes #5 
## Overview

Implemented a **Clue Management System** for the Hunty scavenger-hunt contract. Hunt creators can add clues to Draft hunts; answers are hashed with SHA256 before storage and never exposed on-chain or in events.

---

## 1. Types (`contracts/hunty-core/src/types.rs`)

| Change | Description |
|--------|-------------|
| **`Clue`** | Simplified to `clue_id`, `question`, `answer_hash` (`BytesN<32>`), `points`, `is_required`. Removed `hint`, `location`, `has_location`. |
| **`ClueInfo`** | New type for public API: same as `Clue` but **without** `answer_hash`. Used by `get_clue` and `list_clues`. |
| **`ClueAddedEvent`** | New event: `hunt_id`, `clue_id`, `creator`, `question`, `points`, `is_required`. Answer hash is **never** emitted. |
| **`BytesN`** | Import added for `answer_hash` storage. |
| **`Location`** | Retained for future use; not used in add/get/list clue flow. |

---

## 2. Errors (`contracts/hunty-core/src/errors.rs`)

| Change | Description |
|--------|-------------|
| **`TooManyClues`** | New variant when a hunt already has the max number of clues (100). |
| **`InvalidQuestion`** | New variant when question is empty or exceeds max length (2000 chars). |
| **`From<HuntError>` → `HuntErrorCode`** | Fixed mapping for unit variants (`InvalidHuntStatus`, `InvalidAnswer`, `Unauthorized`, `InvalidAddress`) so they match without `{ .. }`. |
| **`Display`** | Implemented for `TooManyClues` and `InvalidQuestion`. |

---

## 3. Storage (`contracts/hunty-core/src/storage.rs`)

| Change | Description |
|--------|-------------|
| **`CLUE_COUNTER_KEY`** | New symbol for per-hunt clue counters. |
| **`clue_counter_key(hunt_id)`** | Helper for `(CLUE_COUNTER_KEY, hunt_id)` storage key. |
| **`next_clue_id(env, hunt_id)`** | Increments and returns the next clue ID for a hunt (1, 2, 3, …). |
| **`get_clue_counter(env, hunt_id)`** | Returns current clue count for a hunt. |

Existing clue storage (`save_clue`, `get_clue`, `list_clues_for_hunt`, composite keys) is unchanged; it now works with the new `Clue` shape.

---

## 4. Contract Logic (`contracts/hunty-core/src/lib.rs`)

### `add_clue(env, hunt_id, question, answer, points, is_required) → Result<u32, HuntErrorCode>`

- **Auth:** `hunt.creator.require_auth()` — only the hunt creator can add clues.
- **Validation:** Hunt exists, status is **Draft**; question non-empty and ≤ 2000 chars; answer non-empty, ≤ 256 chars, not all whitespace.
- **Limit:** Max **100** clues per hunt (`TooManyClues` otherwise).
- **Normalization:** Answer is trimmed and lowercased (ASCII) before hashing.
- **Hashing:** SHA256 via `env.crypto().sha256()`; stored as `BytesN<32>`.
- **IDs:** Sequential `clue_id` per hunt via `Storage::next_clue_id`.
- **Side effects:** Saves `Clue`, increments `hunt.total_clues`, emits `ClueAddedEvent` (no hash).

### `get_clue(env, hunt_id, clue_id) → Result<ClueInfo, HuntErrorCode>`

- Returns `ClueInfo` (question, points, is_required) for a clue. **Answer hash is never returned.**

### `list_clues(env, hunt_id) → Vec<ClueInfo>`

- Returns all clues for a hunt as `ClueInfo`. **Answer hashes are never returned.**

### Helpers

- **`normalize_and_hash_answer(env, answer)`** — trim, ASCII lowercase, then SHA256; returns `BytesN<32>` or `InvalidAnswer`.
- **`is_ascii_space(b)`** — used for trimming.

### Constants

- `MAX_QUESTION_LENGTH = 2000`
- `MAX_ANSWER_LENGTH = 256`
- `MAX_CLUES_PER_HUNT = 100`

---

## 5. Tests (`contracts/hunty-core/src/test.rs`)

| Test | Purpose |
|------|---------|
| `test_add_clue_success` | Create hunt, add clue, assert `clue_id`, `total_clues`, `get_clue`, `list_clues`. |
| `test_add_clue_unauthorized` | No `mock_all_auths` → `add_clue` panics. |
| `test_add_clue_sequential_ids` | Three clues → IDs 1, 2, 3. |
| `test_add_clue_answer_normalization_and_hashing` | `"  ANSWER  "` and `"answer"` produce the same hash. |
| `test_get_clue_excludes_answer_hash` | `get_clue` returns `ClueInfo` without hash. |
| `test_get_clue_not_found` | `ClueNotFound` for missing clue. |
| `test_list_clues_empty` | No clues → empty list. |
| `test_list_clues_returns_all` | Multiple clues → all returned as `ClueInfo`. |
| `test_add_clue_hunt_not_found` | `HuntNotFound` for invalid `hunt_id`. |
| `test_add_clue_invalid_question_empty` | `InvalidQuestion` for empty question. |
| `test_add_clue_invalid_answer_empty` | `InvalidAnswer` for empty answer. |
| `test_add_clue_invalid_answer_whitespace_only` | `InvalidAnswer` for whitespace-only answer. |
| `test_add_clue_too_many_clues` | 100 clues then one more → `TooManyClues`. |
| `test_add_clue_invalid_hunt_status_not_draft` | Hunt set to Active → `InvalidHuntStatus`. |
| `test_add_clue_invalid_question_too_long` | Question &gt; 2000 chars → `InvalidQuestion`. |

All **32** unit tests pass (including existing `create_hunt` tests).

---

## 6. Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Only hunt creators can add clues | ✅ `require_auth(creator)` |
| Answers hashed before storage | ✅ SHA256, stored as `BytesN<32>` |
| Sequential clue IDs per hunt | ✅ `next_clue_id` |
| Clues retrievable by hunt + clue ID | ✅ `get_clue` |
| All clues for a hunt listable | ✅ `list_clues` |
| Unit tests for auth, hashing, storage | ✅ |
| Edge cases (max clues, invalid hunt, etc.) | ✅ |

---

## Git

- **Branch:** `feat/clue-management-system`
- **Commit:** `feat: implement clue management system`
