### PR TITLE
fix: exclude hunt description from NFT metadata to prevent answer/sal…

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -454,12 +454,16 @@ impl HuntyCore {
             } else {
                 None
             };
+            // description is intentionally excluded from NFT metadata: a creator could
+            // accidentally embed an answer or salt in the hunt description, which would
+            // then be permanently exposed on-chain via the cross-contract call.
+            // Only the title (already fully public) is forwarded.
             let (nft_contract, nft_title, nft_desc, nft_uri, nft_hunt_title) = if nft_awarded {
                 hunt.reward_config.nft_contract.clone().map(|nft_contract| {
                     (
                         Some(nft_contract),
                         hunt.title.clone(),
-                        hunt.description.clone(),
+                        String::from_str(&env, ""),
                         String::from_str(&env, ""),
                         hunt.title.clone(),
                     )


### PR DESCRIPTION
…t leak

hunt.description is creator-supplied free text. If a creator accidentally embeds a clue answer or salt in the description, passing it as nft_description in the cross-contract distribute_rewards call would permanently expose it on-chain in the NFT record.

Only hunt.title (already fully public, shown to all players) is forwarded. nft_description is now always an empty string.
closes #56 