### PR TITLE
fix: add queried_at timestamp to LeaderboardEntry for frontend cache …

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -748,6 +748,7 @@ impl HuntyCore {
     ) -> Result<Vec<LeaderboardEntry>, HuntErrorCode> {
         let _ = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
         let effective_limit = core::cmp::min(limit, MAX_LEADERBOARD_SIZE);
+        let queried_at = env.ledger().timestamp();
         let players = Storage::get_hunt_players(&env, hunt_id);
         let scan_limit = core::cmp::min(players.len(), MAX_LEADERBOARD_SCAN_SIZE);
         let mut entries = Vec::new(&env);
@@ -772,6 +773,7 @@ impl HuntyCore {
                     score,
                     completed_at,
                     is_completed,
+                    queried_at,
                 });
             } else {
                 break;

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -246,6 +246,9 @@ pub struct AnswerIncorrectEvent {
 }
 
 /// Leaderboard entry for a single player in a hunt (read-only query result).
+/// `queried_at` is the ledger timestamp at the moment the leaderboard was fetched,
+/// giving frontend caches a reliable "last refreshed" anchor distinct from
+/// the per-player `completed_at`.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LeaderboardEntry {
@@ -254,6 +257,7 @@ pub struct LeaderboardEntry {
     pub score: u32,
     pub completed_at: u64,
     pub is_completed: bool,
+    pub queried_at: u64,
 }
 
 /// Aggregate statistics for a hunt (read-only query result).


### PR DESCRIPTION
…clarity

completed_at is per-player and 0 for incomplete entries, giving frontends no reliable signal for when the snapshot was taken.

queried_at is set once from env.ledger().timestamp() at query time and stamped on every entry in the response, so caches know exactly how stale the leaderboard data is.

closes #57 