### PR TITLE
[46] [MEDIUM] Hardcoded NFT Rarity/Tier in complete_hunt

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -83,6 +83,8 @@ impl HuntyCore {
             false, // nft_enabled: false initially
             None,  // nft_contract: None initially
             0,     // max_winners: 0 initially
+            0,     // nft_rarity: 0 initially
+            0,     // nft_tier: 0 initially
         );
 
         // Create the hunt with Draft status
@@ -484,8 +486,8 @@ impl HuntyCore {
                 nft_description: nft_desc,
                 nft_image_uri: nft_uri,
                 nft_hunt_title,
-                nft_rarity: 0,
-                nft_tier: 0,
+                nft_rarity: hunt.reward_config.nft_rarity,
+                nft_tier: hunt.reward_config.nft_tier,
             };
 
             // Only call RewardManager when there is at least one reward type

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1988,6 +1988,8 @@ mod test {
                 false,
                 None,
                 max_winners,
+                0,
+                0,
             );
             Storage::save_hunt(env, &hunt);
 
@@ -2069,6 +2071,8 @@ mod test {
                 true,
                 Some(nft_contract_id.clone()),
                 3,
+                0,
+                0,
             );
             Storage::save_hunt(env, &hunt);
 
@@ -2255,6 +2259,8 @@ mod test {
                 true,
                 Some(nft_contract_id.clone()),
                 3,
+                0,
+                0,
             );
             Storage::save_hunt(env, &hunt);
 
@@ -2405,7 +2411,7 @@ mod test {
 
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
             hunt.reward_config =
-                crate::types::RewardConfig::new(1000, false, None, 5);
+                crate::types::RewardConfig::new(1000, false, None, 5, 0, 0);
             Storage::save_hunt(env, &hunt);
 
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -17,6 +17,10 @@ pub struct RewardConfig {
     pub nft_contract: Option<Address>,
     pub max_winners: u32,
     pub claimed_count: u32,
+    /// NFT rarity: 0 = default, 1-5 = common to legendary.
+    pub nft_rarity: u32,
+    /// NFT tier: 0 = none, custom tier value.
+    pub nft_tier: u32,
 }
 
 #[contracttype]
@@ -153,6 +157,8 @@ impl RewardConfig {
         nft_enabled: bool,
         nft_contract: Option<Address>,
         max_winners: u32,
+        nft_rarity: u32,
+        nft_tier: u32,
     ) -> Self {
         Self {
             xlm_pool,
@@ -160,6 +166,8 @@ impl RewardConfig {
             nft_contract,
             max_winners,
             claimed_count: 0,
+            nft_rarity,
+            nft_tier,
         }
     }
 


### PR DESCRIPTION
closes #46 
## Summary

When HuntyCore calls RewardManager in complete_hunt, it was hardcoding 
ft_rarity and 
ft_tier to 