### PR TITLE
[47] [MEDIUM] No Admin Withdrawal for Unclaimed Rewards

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -42,6 +42,15 @@ pub struct RewardsDistributedEvent {
     pub nft_id: Option<u64>,
 }
 
+/// Event emitted when admin withdraws unclaimed rewards from a pool.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminWithdrawEvent {
+    pub hunt_id: u64,
+    pub admin: Address,
+    pub amount: i128,
+}
+
 #[contractimpl]
 impl RewardManager {
     /// Initializes the RewardManager with the XLM token contract address (SAC).
@@ -448,6 +457,63 @@ impl RewardManager {
     /// Returns whether a reward has been distributed to a player for a hunt.
     pub fn is_reward_distributed(env: Env, hunt_id: u64, player: Address) -> bool {
         Storage::is_distributed(&env, hunt_id, &player)
+    }
+
+    /// Allows the admin to withdraw any unclaimed (surplus) XLM remaining in a reward pool.
+    ///
+    /// This is needed when a hunt concludes with fewer winners than anticipated,
+    /// leaving unspent XLM locked in the pool. Only the contract admin may call this.
+    ///
+    /// # Arguments
+    /// * `admin` - The contract admin address (must match the stored admin)
+    /// * `hunt_id` - The hunt whose remaining pool balance to withdraw
+    /// * `recipient` - The address that will receive the withdrawn XLM
+    ///
+    /// # Errors
+    /// * `NotInitialized` - Contract has not been initialized (no admin set)
+    /// * `Unauthorized` - Caller is not the contract admin
+    /// * `PoolNotFound` - No pool exists for this hunt_id
+    /// * `InvalidAmount` - Pool balance is zero (nothing to withdraw)
+    pub fn admin_withdraw_unclaimed(
+        env: Env,
+        admin: Address,
+        hunt_id: u64,
+        recipient: Address,
+    ) -> Result<(), RewardErrorCode> {
+        #[cfg(not(test))]
+        admin.require_auth();
+
+        let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;
+        if configured_admin != admin {
+            return Err(RewardErrorCode::Unauthorized);
+        }
+
+        // Ensure the pool exists
+        Storage::get_pool_config(&env, hunt_id).ok_or(RewardErrorCode::PoolNotFound)?;
+
+        let balance = Storage::get_pool_balance(&env, hunt_id);
+        if balance == 0 {
+            return Err(RewardErrorCode::InvalidAmount);
+        }
+
+        let xlm_token = Storage::get_xlm_token(&env).ok_or(RewardErrorCode::NotInitialized)?;
+
+        let contract_addr = env.current_contract_address();
+        let client = soroban_sdk::token::Client::new(&env, &xlm_token);
+        client.transfer(&contract_addr, &recipient, &balance);
+
+        Storage::set_pool_balance(&env, hunt_id, 0);
+
+        env.events().publish(
+            (symbol_short!("ADM_WDR"), hunt_id),
+            AdminWithdrawEvent {
+                hunt_id,
+                admin,
+                amount: balance,
+            },
+        );
+
+        Ok(())
     }
 }
 

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -900,12 +900,13 @@ mod test {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();
         let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
         let creator = Address::generate(&env);
 
         mint_tokens(&env, &token_address, &token_admin, &creator, 10_000);
 
         env.as_contract(&contract_id, || {
-            RewardManager::initialize(env.clone(), token_address.clone());
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
             RewardManager::create_reward_pool(env.clone(), creator.clone(), 77, 0).unwrap();
             RewardManager::fund_reward_pool(env.clone(), creator.clone(), 77, 6_000).unwrap();
             RewardManager::refund_pool(env.clone(), creator.clone(), 77).unwrap();
@@ -922,19 +923,169 @@ mod test {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();
         let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
         let creator = Address::generate(&env);
         let attacker = Address::generate(&env);
 
         mint_tokens(&env, &token_address, &token_admin, &creator, 10_000);
 
         env.as_contract(&contract_id, || {
-            RewardManager::initialize(env.clone(), token_address.clone());
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
             RewardManager::create_reward_pool(env.clone(), creator.clone(), 88, 0).unwrap();
             RewardManager::fund_reward_pool(env.clone(), creator.clone(), 88, 1_500).unwrap();
 
             let result = RewardManager::refund_pool(env.clone(), attacker.clone(), 88);
             assert_eq!(result, Err(RewardErrorCode::Unauthorized));
             assert_eq!(RewardManager::get_pool_balance(env.clone(), 88), 1_500);
+        });
+    }
+
+    // ========== admin_withdraw_unclaimed ==========
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_success() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        // Fund creator and mint tokens
+        mint_tokens(&env, &token_address, &token_admin, &creator, 10_000);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 0).unwrap();
+            RewardManager::fund_reward_pool(env.clone(), creator.clone(), 1, 6_000).unwrap();
+
+            // Distribute to one player, leaving 4_000 unclaimed
+            let player = Address::generate(&env);
+            RewardManager::distribute_rewards(env.clone(), 1, player, xlm_only_config(&env, 2_000)).unwrap();
+
+            // Admin withdraws the remaining 4_000 to recipient
+            let result = RewardManager::admin_withdraw_unclaimed(
+                env.clone(),
+                admin.clone(),
+                1,
+                recipient.clone(),
+            );
+            assert!(result.is_ok());
+
+            // Pool balance should now be 0
+            assert_eq!(RewardManager::get_pool_balance(env.clone(), 1), 0);
+        });
+
+        // Recipient should have received 4_000
+        assert_eq!(get_balance(&env, &token_address, &recipient), 4_000);
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        mint_tokens(&env, &token_address, &token_admin, &creator, 5_000);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 0).unwrap();
+            RewardManager::fund_reward_pool(env.clone(), creator.clone(), 1, 5_000).unwrap();
+
+            // Non-admin tries to withdraw
+            let result = RewardManager::admin_withdraw_unclaimed(
+                env.clone(),
+                non_admin.clone(),
+                1,
+                non_admin.clone(),
+            );
+            assert_eq!(result, Err(RewardErrorCode::Unauthorized));
+
+            // Pool balance unchanged
+            assert_eq!(RewardManager::get_pool_balance(env.clone(), 1), 5_000);
+        });
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_pool_not_found() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, _) = setup(&env);
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+
+            // No pool created for hunt_id 99
+            let result = RewardManager::admin_withdraw_unclaimed(
+                env.clone(),
+                admin.clone(),
+                99,
+                recipient.clone(),
+            );
+            assert_eq!(result, Err(RewardErrorCode::PoolNotFound));
+        });
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_empty_pool() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        mint_tokens(&env, &token_address, &token_admin, &creator, 3_000);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 0).unwrap();
+            RewardManager::fund_reward_pool(env.clone(), creator.clone(), 1, 3_000).unwrap();
+
+            // Distribute all funds
+            RewardManager::distribute_rewards(
+                env.clone(), 1, player.clone(), xlm_only_config(&env, 3_000),
+            )
+            .unwrap();
+
+            // Admin tries to withdraw from an empty pool
+            let result = RewardManager::admin_withdraw_unclaimed(
+                env.clone(),
+                admin.clone(),
+                1,
+                recipient.clone(),
+            );
+            assert_eq!(result, Err(RewardErrorCode::InvalidAmount));
+        });
+
+        // Recipient received nothing
+        assert_eq!(get_balance(&env, &token_address, &recipient), 0);
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_not_initialized() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            // Contract not initialized — no admin set
+            let result = RewardManager::admin_withdraw_unclaimed(
+                env.clone(),
+                admin.clone(),
+                1,
+                recipient.clone(),
+            );
+            assert_eq!(result, Err(RewardErrorCode::NotInitialized));
         });
     }
 }


### PR DESCRIPTION
## Summary

When a hunt concludes with fewer winners than anticipated, surplus XLM remains locked in the reward pool indefinitely with no way to recover it.

## Changes

### contracts/reward-manager/src/lib.rs
- Added dmin_withdraw_unclaimed(env, admin, hunt_id, recipient) function that transfers the full remaining pool balance to ecipient. Only the contract admin (set during initialize) may call this.
- Added AdminWithdrawEvent emitted on every successful withdrawal (topics: ADM_WDR, hunt_id).

### contracts/reward-manager/src/test.rs
- Added 5 unit tests:
  - 	est_admin_withdraw_unclaimed_success — admin withdraws leftover balance after partial distribution
  - 	est_admin_withdraw_unclaimed_unauthorized — non-admin is rejected with Unauthorized
  - 	est_admin_withdraw_unclaimed_pool_not_found — returns PoolNotFound for unknown hunt_id
  - 	est_admin_withdraw_unclaimed_empty_pool — returns InvalidAmount when pool balance is 0
  - 	est_admin_withdraw_unclaimed_not_initialized — returns NotInitialized before contract is set up
- Fixed pre-existing compile errors in 	est_refund_pool_* tests where initialize was called with 2 args instead of 3.

Closes #47