### PR TITLE
closes #49: use MAX_ANSWER_LENGTH for normalization buffer

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -228,7 +228,7 @@ impl HuntyCore {
         if n > MAX_ANSWER_LENGTH {
             return Err(HuntError::InvalidAnswer);
         }
-        let mut buf = [0u8; 256];
+        let mut buf = [0u8; MAX_ANSWER_LENGTH as usize];
         answer.copy_into_slice(&mut buf[..n as usize]);
         let mut start = 0usize;
         let mut end = n as usize;


### PR DESCRIPTION
Fix Answer Normalization Buffer Limit (#49) Description: This PR addresses issue #49 by replacing the hardcoded [u8; 256] buffer in the normalize_and_hash_answer function with a size derived from the MAX_ANSWER_LENGTH constant. This ensures that any future updates to the maximum answer length will be safely reflected in the normalization logic, avoiding silent panics or buffer overflows.

Closes: #49 