### PR TITLE
fix(reward-manager): clarify distribute_rewards_legacy docstring

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -397,17 +397,17 @@ impl RewardManager {
         Ok(())
     }
 
-    /// Legacy entry point for XLM-only or XLM + NFT (placeholder) distribution.
-    /// Kept for backward compatibility with HuntyCore. For full config support use distribute_rewards.
+    /// Legacy entry point for XLM-only distribution.
+    /// Kept for backward compatibility with HuntyCore. For NFT or full config support use distribute_rewards.
     ///
-    /// Note: When nft_enabled is true, NFT distribution is NOT performed by this legacy path
-    /// (metadata/contract not available). Use distribute_rewards with RewardConfig for NFT support.
+    /// Note: `nft_enabled` is ignored — NFT distribution requires metadata and a contract address
+    /// that are not available on this path. Use `distribute_rewards` with `RewardConfig` instead.
     pub fn distribute_rewards_legacy(
         env: Env,
         player: Address,
         hunt_id: u64,
         xlm_amount: i128,
-        _nft_enabled: bool,
+        _nft_enabled: bool, // ignored: NFT not supported on legacy path
     ) -> bool {
         let config = RewardConfig {
             xlm_amount: if xlm_amount > 0 {


### PR DESCRIPTION
The previous docstring described the function as supporting 'XLM + NFT (placeholder) distribution', which contradicted the note below it stating NFT distribution is not performed on this path.

- Rewrite first line to 'XLM-only distribution' (unambiguous)
- Explain *why* NFT is unsupported (missing metadata/contract address)
- Add inline comment on _nft_enabled parameter to surface the ignore at the call-site level, not just in the docstring

Closes #51