### PR TITLE
refactor(hunty-core): eliminate duplicate player/hunt_id in PlayerProgress storage

### DIFF
--- a/contracts/hunty-core/src/storage.rs
+++ b/contracts/hunty-core/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::errors::HuntError;
-use crate::types::{Clue, Hunt, PlayerProgress};
+use crate::types::{Clue, Hunt, PlayerProgress, StoredPlayerProgress};
 use soroban_sdk::{symbol_short, Address, Env, Vec};
 
 /// Storage access layer for hunts, clues, and player progress.
@@ -139,9 +139,9 @@ impl Storage {
     /// * `env` - The Soroban environment
     /// * `progress` - The PlayerProgress struct to store
     pub fn save_player_progress(env: &Env, progress: &PlayerProgress) {
-        // Store the progress with composite key (hunt_id + player address)
+        // Store only the compact form — player and hunt_id are already the key
         let key = Self::progress_key(progress.hunt_id, &progress.player);
-        env.storage().persistent().set(&key, progress);
+        env.storage().persistent().set(&key, &progress.to_stored());
 
         // Update the list of players for this hunt
         Self::add_player_to_list(env, progress.hunt_id, &progress.player);
@@ -162,7 +162,10 @@ impl Storage {
         player: &Address,
     ) -> Option<PlayerProgress> {
         let key = Self::progress_key(hunt_id, player);
-        env.storage().persistent().get(&key)
+        env.storage()
+            .persistent()
+            .get::<_, StoredPlayerProgress>(&key)
+            .map(|stored| PlayerProgress::from_stored(stored, player.clone(), hunt_id))
     }
 
     /// Retrieves player progress or returns an error if not found.

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -97,6 +97,20 @@ impl Default for Location {
     }
 }
 
+/// Internal storage representation of player progress.
+/// Does not store `player` or `hunt_id` — those are already the storage key.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StoredPlayerProgress {
+    pub completed_clues: Vec<u32>,
+    pub total_score: u32,
+    pub started_at: u64,
+    pub completed_at: u64,
+    pub is_completed: bool,
+    pub reward_claimed: bool,
+}
+
+/// Public view of player progress, with `player` and `hunt_id` reconstructed from the key.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct PlayerProgress {
@@ -121,6 +135,32 @@ impl PlayerProgress {
             completed_at: 0,
             is_completed: false,
             reward_claimed: false,
+        }
+    }
+
+    /// Convert to the compact form stored on-chain (drops redundant key fields).
+    pub fn to_stored(&self) -> StoredPlayerProgress {
+        StoredPlayerProgress {
+            completed_clues: self.completed_clues.clone(),
+            total_score: self.total_score,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            is_completed: self.is_completed,
+            reward_claimed: self.reward_claimed,
+        }
+    }
+
+    /// Reconstruct from stored form plus the key fields.
+    pub fn from_stored(stored: StoredPlayerProgress, player: Address, hunt_id: u64) -> Self {
+        Self {
+            player,
+            hunt_id,
+            completed_clues: stored.completed_clues,
+            total_score: stored.total_score,
+            started_at: stored.started_at,
+            completed_at: stored.completed_at,
+            is_completed: stored.is_completed,
+            reward_claimed: stored.reward_claimed,
         }
     }
 


### PR DESCRIPTION


Closes #50 

PlayerProgress stored player and hunt_id redundantly — those values are already encoded in the storage key (PROGRESS_KEY, hunt_id, player).

Changes:
- Add StoredPlayerProgress: a compact on-chain struct without player/hunt_id
- Add PlayerProgress::to_stored() to convert to the compact form
- Add PlayerProgress::from_stored() to reconstruct the full view from key fields
- Update save_player_progress to persist StoredPlayerProgress instead of PlayerProgress
- Update get_player_progress to deserialise StoredPlayerProgress and rehydrate player/hunt_id from the key