### PR TITLE
feat: add validate_rarity guard (nft_rarity must be 0-5)

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -27,6 +27,7 @@ pub enum HuntErrorCode {
     RewardDistributionFailed = 20,
     NoRewardsConfigured = 21,
     NoRequiredClues = 22,
+    InvalidRarity = 23,
 }
 
 #[derive(Debug)]
@@ -51,6 +52,7 @@ pub enum HuntError {
     RewardDistributionFailed { hunt_id: u64 },
     NoRewardsConfigured { hunt_id: u64 },
     NoRequiredClues { hunt_id: u64 },
+    InvalidRarity { value: u32 },
 }
 
 impl fmt::Display for HuntError {
@@ -123,6 +125,9 @@ impl fmt::Display for HuntError {
             HuntError::NoRequiredClues { hunt_id } => {
                 write!(f, "Hunt {} has no required clues; at least one required clue must exist before activation", hunt_id)
             }
+            HuntError::InvalidRarity { value } => {
+                write!(f, "Invalid nft_rarity {}: must be 0-5", value)
+            }
         }
     }
 }
@@ -150,6 +155,7 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::RewardDistributionFailed { .. } => HuntErrorCode::RewardDistributionFailed,
             HuntError::NoRewardsConfigured { .. } => HuntErrorCode::NoRewardsConfigured,
             HuntError::NoRequiredClues { .. } => HuntErrorCode::NoRequiredClues,
+            HuntError::InvalidRarity { .. } => HuntErrorCode::InvalidRarity,
         }
     }
 }

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -257,6 +257,11 @@ impl HuntyCore {
         b == 0x20 || b == 0x09 || b == 0x0a || b == 0x0d
     }
 
+    #[inline]
+    fn validate_rarity(v: u32) -> bool {
+        v <= 5
+    }
+
     pub fn activate_hunt(env: Env, hunt_id: u64, caller: Address) -> Result<(), HuntErrorCode> {
         let mut hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
 
@@ -492,6 +497,10 @@ impl HuntyCore {
 
         let reward_amount = hunt.reward_config.reward_per_winner();
         let nft_awarded = hunt.reward_config.nft_enabled;
+
+        if !Self::validate_rarity(hunt.reward_config.nft_rarity) {
+            return Err(HuntErrorCode::InvalidRarity);
+        }
 
         // Call RewardManager if configured and there are rewards to distribute
         if let Some(reward_manager_addr) = Storage::get_reward_manager(env) {

--- a/contracts/nft-reward/src/errors.rs
+++ b/contracts/nft-reward/src/errors.rs
@@ -9,4 +9,5 @@ pub enum NftErrorCode {
     NotOwner = 3,
     InvalidRecipient = 4,
     SoulboundNft = 5,
+    InvalidRarity = 6,
 }

--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -102,6 +102,9 @@ impl NftReward {
         player_address: Address,
         metadata: NftMetadata,
     ) -> u64 {
+        if metadata.rarity > 5 {
+            panic!("InvalidRarity");
+        }
         let minted_at = env.ledger().timestamp();
 
         let nft_id = Storage::next_nft_id(&env);
@@ -174,6 +177,10 @@ impl NftReward {
             .get(Symbol::new(&env, "rarity"))
             .and_then(|v| u32::try_from_val(&env, &v).ok())
             .unwrap_or(0u32);
+
+        if rarity > 5 {
+            panic!("InvalidRarity");
+        }
 
         let tier = metadata
             .get(Symbol::new(&env, "tier"))

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -351,6 +351,9 @@ impl RewardManager {
 
         // Route to NFT handler if configured
         if reward_config.has_nft() {
+            if reward_config.nft_rarity > 5 {
+                return Err(RewardErrorCode::InvalidConfig);
+            }
             let nft_contract = reward_config
                 .nft_contract
                 .as_ref()


### PR DESCRIPTION
- Add InvalidRarity = 23 to HuntErrorCode and HuntError in hunty-core
- Add private validate_rarity(v: u32) -> bool helper in lib.rs
- Guard nft_rarity in process_reward_distribution before cross-contract call
- Add InvalidRarity = 6 to NftErrorCode in nft-reward
- Guard rarity in mint_reward_nft and mint_reward_nft_from_map with panic
- Guard nft_rarity in reward-manager distribute_rewards before NFT dispatch
- All existing paths unaffected: rarity defaults to 0 everywhere

closes #103