### PR TITLE
feat(hunty-core): add InvalidPoints error for zero points in add_clue

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -27,6 +27,7 @@ pub enum HuntErrorCode {
     RewardDistributionFailed = 20,
     NoRewardsConfigured = 21,
     NoRequiredClues = 22,
+    InvalidPoints = 23,
 }
 
 #[derive(Debug)]
@@ -51,6 +52,7 @@ pub enum HuntError {
     RewardDistributionFailed { hunt_id: u64 },
     NoRewardsConfigured { hunt_id: u64 },
     NoRequiredClues { hunt_id: u64 },
+    InvalidPoints,
 }
 
 impl fmt::Display for HuntError {
@@ -123,6 +125,9 @@ impl fmt::Display for HuntError {
             HuntError::NoRequiredClues { hunt_id } => {
                 write!(f, "Hunt {} has no required clues; at least one required clue must exist before activation", hunt_id)
             }
+            HuntError::InvalidPoints => {
+                write!(f, "Invalid points: points must be >= 1")
+            }
         }
     }
 }
@@ -150,6 +155,7 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::RewardDistributionFailed { .. } => HuntErrorCode::RewardDistributionFailed,
             HuntError::NoRewardsConfigured { .. } => HuntErrorCode::NoRewardsConfigured,
             HuntError::NoRequiredClues { .. } => HuntErrorCode::NoRequiredClues,
+            HuntError::InvalidPoints => HuntErrorCode::InvalidPoints,
         }
     }
 }

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -161,6 +161,9 @@ impl HuntyCore {
         if qlen == 0 || qlen > MAX_QUESTION_LENGTH {
             return Err(HuntErrorCode::InvalidQuestion);
         }
+        if points == 0 {
+            return Err(HuntErrorCode::InvalidPoints);
+        }
         let answer_hash =
             Self::normalize_and_hash_answer(&env, &answer).map_err(HuntErrorCode::from)?;
         let clue_id = Storage::next_clue_id(&env, hunt_id);

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -814,6 +814,26 @@ mod test {
     }
 
     #[test]
+    fn test_add_clue_zero_points() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Hunt");
+        let description = String::from_str(&env, "Desc");
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let err = with_core_contract(&env, |env, _cid| {
+            let hid = HuntyCore::create_hunt(env.clone(), creator, title, description, None, None)
+                .unwrap();
+            HuntyCore::add_clue(env.clone(), hid, question, answer, 0, false).unwrap_err()
+        });
+
+        assert_eq!(err, HuntErrorCode::InvalidPoints);
+    }
+
+    #[test]
     fn test_activate_hunt_success() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);


### PR DESCRIPTION
Closes #105 

# PR: Enforce Minimum Points Validation for Clues

## Summary
Enforce that clues must have a minimum of 1 point (`points >= 1`) in the `add_clue` function. Zero-point clues are now rejected to prevent scoring system inconsistencies and leaderboard comparison issues.

## Problem Statement
The `add_clue` function accepted `points: u32` with no minimum validation, allowing zero-point clues to be created. This can:
- Skew the scoring system by allowing clues that contribute zero value
- Create inconsistencies in leaderboard calculations
- Enable potentially exploitative behavior where clues exist but provide no reward

## Solution
Add explicit validation to reject clues with `points == 0`, enforcing a minimum of 1 point per clue.

## Changes

### 1. Error Handling ([contracts/hunty-core/src/errors.rs](contracts/hunty-core/src/errors.rs))
- **Added error code**: `InvalidPoints = 23` to `HuntErrorCode` enum
- **Added error variant**: `InvalidPoints` to `HuntError` enum
- **Error message**: "Invalid points: points must be >= 1"
- **Error mapping**: Updated `From<HuntError>` implementation to map `InvalidPoints`

### 2. Validation Logic ([contracts/hunty-core/src/lib.rs](contracts/hunty-core/src/lib.rs))
- **Function**: `add_clue()`
- **Added validation**: Check `if points == 0` immediately after question validation
- **Behavior**: Returns `HuntErrorCode::InvalidPoints` when points is zero
- **Placement**: Validation occurs before answer normalization/hashing to fail fast

### 3. Test Coverage ([contracts/hunty-core/src/test.rs](contracts/hunty-core/src/test.rs))
- **New test**: `test_add_clue_zero_points()`
- **Scenario**: Attempts to add a clue with `points: 0` to a draft hunt
- **Expected**: Returns `HuntErrorCode::InvalidPoints`
- **Pattern**: Follows existing test structure and conventions

## Validation Order
```
1. Hunt existence check
2. Hunt status validation (must be Draft)
3. Authorization check (creator authentication)
4. Clue count limit (MAX_CLUES_PER_HUNT)
5. Question validation (length constraints)
6. **NEW: Points validation (points >= 1)**  ← Added here
7. Answer validation (normalization & hashing)
8. Clue creation and storage
```

## Backward Compatibility
⚠️ **Breaking Change**: Existing code paths that attempt to create zero-point clues will now fail with `HuntErrorCode::InvalidPoints`. Hunt creators must specify `points >= 1`.

## Testing
- ✅ All existing tests pass (no breaking changes to valid scenarios)
- ✅ New test `test_add_clue_zero_points()` validates rejection behavior
- ✅ No compilation errors in error handling or lib code

## Implementation Details

### Error Code Assignment
- Error code `23` assigned (next sequential after `NoRequiredClues = 22`)
- Maintains logical error grouping with other validation errors

### Validation Logic
```rust
if points == 0 {
    return Err(HuntErrorCode::InvalidPoints);
}
```

### Error Message
Clear and actionable: "Invalid points: points must be >= 1"

## Related Issues
- Fixes: Zero-point clues skewing scoring system
- Related: Leaderboard consistency, reward distribution accuracy

## Review Notes
- Validation is applied at clue creation time (no retroactive changes needed)
- Error code follows existing `HuntErrorCode` conventions
- Test follows established test patterns with `with_core_contract` helper
- All error path mappings updated consistently
