### PR TITLE
fix: keep reward pool balance in sync

### DIFF
--- a/ISSUE_88_PLACEHOLDER.md
+++ b/ISSUE_88_PLACEHOLDER.md
@@ -1,0 +1,3 @@
+# Placeholder PR for issue #88
+
+Tracking branch for implementation.

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -490,10 +490,28 @@ impl HuntyCore {
             return Err(HuntErrorCode::InsufficientRewardPool);
         }
 
-        let reward_amount = hunt.reward_config.reward_per_winner();
         let nft_awarded = hunt.reward_config.nft_enabled;
 
         // Call RewardManager if configured and there are rewards to distribute
+        let reward_amount = if let Some(reward_manager_addr) = Storage::get_reward_manager(env) {
+            let mut balance_args: Vec<Val> = Vec::new(env);
+            balance_args.push_back(hunt_id.into_val(env));
+
+            let pool_balance = env
+                .try_invoke_contract::<i128, RewardErrorCode>(
+                    &reward_manager_addr,
+                    &Symbol::new(env, "get_pool_balance"),
+                    balance_args,
+                )
+                .map_err(|_| HuntErrorCode::RewardDistributionFailed)?
+                .map_err(|_| HuntErrorCode::RewardDistributionFailed)?;
+
+            hunt.reward_config.xlm_pool = pool_balance;
+            hunt.reward_config.reward_per_winner()
+        } else {
+            hunt.reward_config.reward_per_winner()
+        };
+
         if let Some(reward_manager_addr) = Storage::get_reward_manager(env) {
             let xlm_amount = if reward_amount > 0 {
                 Some(reward_amount)

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1350,7 +1350,7 @@ mod test {
                 HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
 
-            Ok(())
+            
         });
     }
 
@@ -2250,6 +2250,98 @@ mod test {
             nft.metadata.title,
             SorobanString::from_str(&env, "Integrated Hunt")
         );
+    }
+
+    #[test]
+    fn test_complete_hunt_uses_reward_manager_pool_balance_when_local_pool_is_zero() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let funder = Address::generate(&env);
+
+        let (reward_manager_id, token_address, token_admin) = setup_reward_manager(&env, None);
+        let core_id = env.register_contract(None, HuntyCore);
+
+        let hunt_id = as_core_contract(&env, &core_id, |env| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                SorobanString::from_str(env, "Pool-backed hunt"),
+                SorobanString::from_str(env, "Uses reward manager balance"),
+                None,
+                None,
+            )
+            .unwrap();
+
+            HuntyCore::add_clue(
+                env.clone(),
+                hunt_id,
+                SorobanString::from_str(env, "1+1?"),
+                SorobanString::from_str(env, "2"),
+                10,
+                true,
+            )
+            .unwrap();
+
+            let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
+            hunt.reward_config = crate::types::RewardConfig::new(0, false, None, 3, 0, 0);
+            Storage::save_hunt(env, &hunt);
+
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+
+            hunt_id
+        });
+
+        let token_client = token::StellarAssetClient::new(&env, &token_address);
+        token_client.mint(&funder, &9_000);
+        let _ = token_admin;
+
+        env.as_contract(&reward_manager_id, || {
+            RewardManager::create_reward_pool(env.clone(), funder.clone(), hunt_id, 0).unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&reward_manager_id, || {
+            RewardManager::fund_reward_pool(env.clone(), funder.clone(), hunt_id, 9_000).unwrap();
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &core_id, |env| {
+            HuntyCore::set_reward_manager(env.clone(), reward_manager_id.clone());
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &core_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        as_core_contract(&env, &core_id, |env| {
+            HuntyCore::submit_answer(
+                env.clone(),
+                hunt_id,
+                1,
+                player.clone(),
+                SorobanString::from_str(env, "2"),
+            )
+            .unwrap();
+        });
+        env.mock_all_auths();
+        as_core_contract(&env, &core_id, |env| {
+            HuntyCore::complete_hunt(env.clone(), hunt_id, player.clone()).unwrap();
+        });
+
+        let player_balance = token::Client::new(&env, &token_address).balance(&player);
+        assert_eq!(player_balance, 3_000);
+
+        env.as_contract(&reward_manager_id, || {
+            assert_eq!(RewardManager::get_pool_balance(env.clone(), hunt_id), 6_000);
+        });
+
+        let hunt = as_core_contract(&env, &core_id, |env| {
+            HuntyCore::get_hunt_info(env.clone(), hunt_id).unwrap()
+        });
+        assert_eq!(hunt.reward_config.xlm_pool, 9_000);
     }
 
     #[test]


### PR DESCRIPTION
Closes #88

Placeholder PR opened to link the assignment before implementation.

Planned work:
- sync `RewardConfig.xlm_pool` with funding operations or remove the stale field path
- make `reward_per_winner()` read the actual pool balance
- add regression tests for first and subsequent deposits