### PR TITLE
perf: avoid scanning all clues on answer submit

### DIFF
--- a/ISSUE_89_PLACEHOLDER.md
+++ b/ISSUE_89_PLACEHOLDER.md
@@ -1,0 +1,3 @@
+# Placeholder PR for issue #89
+
+Tracking branch for implementation.

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -708,10 +708,10 @@ impl HuntyCore {
             return Err(HuntErrorCode::InvalidAnswer);
         }
 
-        progress.complete_clue(&env, clue_id, clue.points);
+        progress.complete_clue(&env, clue_id, clue.points, clue.is_required);
 
         let all_required_completed =
-            Self::check_all_required_clues_completed(&env, hunt_id, &progress);
+            Self::check_all_required_clues_completed(hunt.required_clues, &progress);
 
         // If all required clues completed, mark hunt as completed for this player
         if all_required_completed && !progress.is_completed {
@@ -756,30 +756,8 @@ impl HuntyCore {
     ///
     /// # Returns
     /// `true` if all required clues are completed, `false` otherwise
-    fn check_all_required_clues_completed(
-        env: &Env,
-        hunt_id: u64,
-        progress: &PlayerProgress,
-    ) -> bool {
-        // Get all clues for the hunt
-        let all_clues = Storage::list_clues_for_hunt(env, hunt_id);
-
-        // Iterate through all clues and check if all required ones are completed
-        for i in 0..all_clues.len() {
-            let clue = all_clues.get(i).unwrap();
-
-            // If this is a required clue
-            if clue.is_required {
-                // Check if player has completed it
-                if !progress.has_completed_clue(clue.clue_id) {
-                    // Found a required clue that's not completed
-                    return false;
-                }
-            }
-        }
-
-        // All required clues are completed
-        true
+    fn check_all_required_clues_completed(required_clue_count: u32, progress: &PlayerProgress) -> bool {
+        progress.required_completed_count >= required_clue_count
     }
 
     /// Returns player progress for a hunt (read-only).

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1350,7 +1350,7 @@ mod test {
                 HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
 
-            Ok(())
+            
         });
     }
 
@@ -1586,9 +1586,166 @@ mod test {
         assert_eq!(progress.player, player);
         assert_eq!(progress.hunt_id, hunt_id);
         assert_eq!(progress.completed_clues.len(), 1);
+        assert_eq!(progress.required_completed_count, 1);
         assert_eq!(progress.total_score, 10);
         assert!(progress.is_completed);
         assert!(progress.completed_at > 0);
+    }
+
+    #[test]
+    fn test_required_completed_counter_marks_completion_without_clue_scan() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let contract_id = env.register_contract(None, HuntyCore);
+        let hunt_id = as_core_contract(&env, &contract_id, |env| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Hunt"),
+                String::from_str(env, "Desc"),
+                None,
+                None,
+            )
+            .unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer.clone(), 10, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            hunt_id
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer).unwrap();
+        });
+
+        let progress = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap()
+        });
+        assert_eq!(progress.required_completed_count, 1);
+        assert!(progress.is_completed);
+    }
+
+    #[test]
+    fn test_required_completed_counter_is_not_double_incremented_on_resubmit() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let contract_id = env.register_contract(None, HuntyCore);
+        let hunt_id = as_core_contract(&env, &contract_id, |env| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Hunt"),
+                String::from_str(env, "Desc"),
+                None,
+                None,
+            )
+            .unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer.clone(), 10, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            hunt_id
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        let resubmit = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer)
+        });
+
+        assert_eq!(resubmit, Err(HuntErrorCode::ClueAlreadyCompleted));
+
+        let progress = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap()
+        });
+        assert_eq!(progress.required_completed_count, 1);
+    }
+
+    #[test]
+    fn test_required_completed_counter_stays_isolated_per_player() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+
+        let creator = Address::generate(&env);
+        let player_a = Address::generate(&env);
+        let player_b = Address::generate(&env);
+        let answer = String::from_str(&env, "a");
+
+        let contract_id = env.register_contract(None, HuntyCore);
+        let hunt_id = as_core_contract(&env, &contract_id, |env| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Hunt"),
+                String::from_str(env, "Desc"),
+                None,
+                None,
+            )
+            .unwrap();
+            HuntyCore::add_clue(
+                env.clone(),
+                hunt_id,
+                String::from_str(env, "Q1"),
+                answer.clone(),
+                5,
+                true,
+            )
+            .unwrap();
+            HuntyCore::add_clue(
+                env.clone(),
+                hunt_id,
+                String::from_str(env, "Q2"),
+                answer.clone(),
+                5,
+                true,
+            )
+            .unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            hunt_id
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player_a.clone()).unwrap();
+            HuntyCore::register_player(env.clone(), hunt_id, player_b.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_a.clone(), answer.clone()).unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 2, player_b.clone(), answer.clone()).unwrap();
+        });
+
+        let progress_a = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player_a.clone()).unwrap()
+        });
+        let progress_b = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player_b.clone()).unwrap()
+        });
+
+        assert_eq!(progress_a.required_completed_count, 1);
+        assert_eq!(progress_b.required_completed_count, 1);
+        assert!(!progress_a.is_completed);
+        assert!(!progress_b.is_completed);
     }
 
     #[test]

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -103,6 +103,7 @@ impl Default for Location {
 #[derive(Clone, Debug)]
 pub struct StoredPlayerProgress {
     pub completed_clues: Vec<u32>,
+    pub required_completed_count: u32,
     pub total_score: u32,
     pub started_at: u64,
     pub completed_at: u64,
@@ -117,6 +118,7 @@ pub struct PlayerProgress {
     pub player: Address,
     pub hunt_id: u64,
     pub completed_clues: Vec<u32>,
+    pub required_completed_count: u32,
     pub total_score: u32,
     pub started_at: u64,
     pub completed_at: u64,
@@ -130,6 +132,7 @@ impl PlayerProgress {
             player,
             hunt_id,
             completed_clues: Vec::new(env),
+            required_completed_count: 0,
             total_score: 0,
             started_at: current_time,
             completed_at: 0,
@@ -142,6 +145,7 @@ impl PlayerProgress {
     pub fn to_stored(&self) -> StoredPlayerProgress {
         StoredPlayerProgress {
             completed_clues: self.completed_clues.clone(),
+            required_completed_count: self.required_completed_count,
             total_score: self.total_score,
             started_at: self.started_at,
             completed_at: self.completed_at,
@@ -156,6 +160,7 @@ impl PlayerProgress {
             player,
             hunt_id,
             completed_clues: stored.completed_clues,
+            required_completed_count: stored.required_completed_count,
             total_score: stored.total_score,
             started_at: stored.started_at,
             completed_at: stored.completed_at,
@@ -173,9 +178,12 @@ impl PlayerProgress {
         false
     }
 
-    pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32) {
+    pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32, is_required: bool) {
         if !self.has_completed_clue(clue_id) {
             self.completed_clues.push_back(clue_id);
+            if is_required {
+                self.required_completed_count += 1;
+            }
             self.total_score += points;
         }
     }


### PR DESCRIPTION
Closes #89

Placeholder PR opened to link the assignment before implementation.

Planned work:
- add a required clue completion counter to player progress
- replace per-submit full clue scans with constant-time completion checks
- add regression coverage for re-submits and multi-player correctness