### PR TITLE
fix(hunty-core): remove no-op match statement in get_hunt_info

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -385,15 +385,6 @@ impl HuntyCore {
 
     pub fn get_hunt_info(env: Env, hunt_id: u64) -> Result<Hunt, HuntErrorCode> {
         let hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
-
-        match hunt.status {
-            HuntStatus::Draft
-            | HuntStatus::Active
-            | HuntStatus::Completed
-            | HuntStatus::Cancelled => {}
-        }
-
-        // Return the full Hunt struct
         Ok(hunt)
     }
 


### PR DESCRIPTION
## Summary

- Removes the dead `match hunt.status { Draft | Active | Completed | Cancelled => {} }` block inside `get_hunt_info` — it matched every variant and did nothing
- Removes the now-redundant `// Return the full Hunt struct` comment
- The function now simply fetches the hunt from storage and returns it

Closes #198

## Test plan

- [ ] Existing `get_hunt_info` tests continue to pass
- [ ] No behaviour change — function return value is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)