### PR TITLE
feat: issue 99

### DIFF
--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -46,6 +46,7 @@ pub struct NftData {
     /// Player who completed the hunt (preserved after transfers).
     pub completion_player: Address,
     pub metadata: NftMetadata,
+    pub transferable: bool,
     pub minted_at: u64,
 }
 
@@ -112,6 +113,7 @@ impl NftReward {
             owner: player_address.clone(),
             completion_player: player_address.clone(),
             metadata: metadata.clone(),
+            transferable: false,
             minted_at,
         };
 
@@ -142,6 +144,7 @@ impl NftReward {
     /// - "hunt_title": String (defaults to title when omitted/empty)
     /// - "rarity": u32
     /// - "tier": u32
+    /// - "transferable": bool
     pub fn mint_reward_nft_from_map(
         env: Env,
         hunt_id: u64,
@@ -180,6 +183,11 @@ impl NftReward {
             .and_then(|v| u32::try_from_val(&env, &v).ok())
             .unwrap_or(0u32);
 
+        let transferable = metadata
+            .get(Symbol::new(&env, "transferable"))
+            .and_then(|v| bool::try_from_val(&env, &v).ok())
+            .unwrap_or(false);
+
         let meta = NftMetadata {
             title,
             description,
@@ -189,7 +197,33 @@ impl NftReward {
             tier,
         };
 
-        Self::mint_reward_nft(env, hunt_id, player_address, meta)
+        let minted_at = env.ledger().timestamp();
+        let nft_id = Storage::next_nft_id(&env);
+
+        let nft_data = NftData {
+            nft_id,
+            hunt_id,
+            owner: player_address.clone(),
+            completion_player: player_address.clone(),
+            metadata: meta.clone(),
+            transferable,
+            minted_at,
+        };
+
+        Storage::save_nft(&env, &nft_data);
+        Storage::add_nft_to_owner(&env, &player_address, nft_id);
+
+        let event = NftMintedEvent {
+            nft_id,
+            hunt_id,
+            owner: player_address,
+            metadata: meta,
+            minted_at,
+        };
+        env.events()
+            .publish((Symbol::new(&env, "NftMinted"), nft_id), event);
+
+        nft_id
     }
 
     /// Retrieves NFT data by ID.
@@ -279,12 +313,43 @@ impl NftReward {
     /// For automatic transfers during reward distribution, the contract may be
     /// the `from_address` when invoked by an authorized party.
     pub fn transfer_nft(
-        _env: Env,
-        _nft_id: u64,
-        _from_address: Address,
-        _to_address: Address,
+        env: Env,
+        nft_id: u64,
+        from_address: Address,
+        to_address: Address,
     ) -> Result<(), crate::errors::NftErrorCode> {
-        Err(crate::errors::NftErrorCode::SoulboundNft)
+        from_address.require_auth();
+
+        let mut nft = Storage::get_nft(&env, nft_id)
+            .ok_or(crate::errors::NftErrorCode::NftNotFound)?;
+
+        if nft.owner != from_address {
+            return Err(crate::errors::NftErrorCode::NotOwner);
+        }
+
+        if nft.owner == to_address {
+            return Err(crate::errors::NftErrorCode::InvalidRecipient);
+        }
+
+        if !nft.transferable {
+            return Err(crate::errors::NftErrorCode::SoulboundNft);
+        }
+
+        Storage::remove_nft_from_owner(&env, &from_address, nft_id);
+        nft.owner = to_address.clone();
+        Storage::save_nft(&env, &nft);
+        Storage::add_nft_to_owner(&env, &to_address, nft_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "NftTransferred"), nft_id),
+            NftTransferredEvent {
+                nft_id,
+                from: from_address,
+                to: to_address,
+            },
+        );
+
+        Ok(())
     }
 }
 

--- a/contracts/nft-reward/src/test.rs
+++ b/contracts/nft-reward/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 use crate::{NftMetadata, NftReward, NftRewardClient};
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, String,
+    Address, Env, IntoVal, Map, String, Symbol, Val,
 };
 
 fn setup_env() -> Env {
@@ -69,6 +69,18 @@ fn test_mint_reward_nft() {
     assert_eq!(nft.metadata.description, metadata.description);
     assert_eq!(nft.metadata.image_uri, metadata.image_uri);
     assert_eq!(nft.minted_at, 1000);
+}
+
+fn create_transferable_metadata(env: &Env, title: &str, desc: &str, image_uri: &str) -> Map<Symbol, Val> {
+    let mut metadata: Map<Symbol, Val> = Map::new(env);
+    metadata.set(Symbol::new(env, "title"), String::from_str(env, title).into_val(env));
+    metadata.set(Symbol::new(env, "description"), String::from_str(env, desc).into_val(env));
+    metadata.set(Symbol::new(env, "image_uri"), String::from_str(env, image_uri).into_val(env));
+    metadata.set(Symbol::new(env, "hunt_title"), String::from_str(env, title).into_val(env));
+    metadata.set(Symbol::new(env, "rarity"), 0u32.into_val(env));
+    metadata.set(Symbol::new(env, "tier"), 0u32.into_val(env));
+    metadata.set(Symbol::new(env, "transferable"), true.into_val(env));
+    metadata
 }
 
 #[test]
@@ -289,16 +301,15 @@ fn test_update_nft_metadata_preserves_immutable_fields() {
 }
 
 #[test]
-#[should_panic]
 fn test_transfer_nft_success() {
     let env = setup_env();
     let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
-    let metadata = create_metadata(&env, "Transfer NFT", "Test transfer", "ipfs://transfer");
+    let metadata = create_transferable_metadata(&env, "Transfer NFT", "Test transfer", "ipfs://transfer");
 
-    let nft_id = client.mint_reward_nft(&1, &from, &metadata);
+    let nft_id = client.mint_reward_nft_from_map(&1, &from, &metadata);
     assert_eq!(client.owner_of(&nft_id), Some(from.clone()));
 
     client.transfer_nft(&nft_id, &from, &to);
@@ -317,10 +328,9 @@ fn test_transfer_nft_updates_player_nfts() {
 
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
-    let metadata1 = create_metadata(&env, "NFT 1", "Desc 1", "ipfs://1");
     let metadata2 = create_metadata(&env, "NFT 2", "Desc 2", "ipfs://2");
-
-    let nft1 = client.mint_reward_nft(&1, &alice, &metadata1);
+    let metadata1 = create_transferable_metadata(&env, "NFT 1", "Desc 1", "ipfs://1");
+    let nft1 = client.mint_reward_nft_from_map(&1, &alice, &metadata1);
     let nft2 = client.mint_reward_nft(&2, &alice, &metadata2);
 
     let alice_nfts = client.get_player_nfts(&alice);
@@ -406,9 +416,9 @@ fn test_transfer_nft_emits_event() {
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
-    let metadata = create_metadata(&env, "Event NFT", "Desc", "ipfs://event");
+    let metadata = create_transferable_metadata(&env, "Event NFT", "Desc", "ipfs://event");
 
-    let nft_id = client.mint_reward_nft(&1, &from, &metadata);
+    let nft_id = client.mint_reward_nft_from_map(&1, &from, &metadata);
     client.transfer_nft(&nft_id, &from, &to);
 
     // Transfer succeeded; NftTransferred event is emitted by transfer_nft


### PR DESCRIPTION
closes #99 

Changes
[lib.rs](https://curly-fortnight-vj465qq76vhjj6.github.dev/)

Added [transferable: bool](https://curly-fortnight-vj465qq76vhjj6.github.dev/) to [NftData](https://curly-fortnight-vj465qq76vhjj6.github.dev/).
Kept default [mint_reward_nft](https://curly-fortnight-vj465qq76vhjj6.github.dev/) behavior as soulbound (false).
Updated [mint_reward_nft_from_map](https://curly-fortnight-vj465qq76vhjj6.github.dev/) to parse optional ["transferable": bool](https://curly-fortnight-vj465qq76vhjj6.github.dev/) metadata and store it.
Implemented [transfer_nft](https://curly-fortnight-vj465qq76vhjj6.github.dev/) to:
require auth,
verify ownership,
reject same-address transfers,
reject soulbound NFTs,
update owner storage and emit NftTransferred.
[test.rs](https://curly-fortnight-vj465qq76vhjj6.github.dev/)

Added helper for creating transferable NFT metadata.
Updated transfer success tests to mint NFTs with [transferable=true](https://curly-fortnight-vj465qq76vhjj6.github.dev/).