### PR TITLE
fix: remove cfg(not(test)) guards from require_auth calls

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -101,7 +101,6 @@ impl RewardManager {
         hunt_id: u64,
         min_distribution_amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
         creator.require_auth();
 
         if min_distribution_amount < 0 {
@@ -152,7 +151,6 @@ impl RewardManager {
         hunt_id: u64,
         amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
         funder.require_auth();
 
         if amount <= 0 {
@@ -480,7 +478,6 @@ impl RewardManager {
         hunt_id: u64,
         recipient: Address,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
         admin.require_auth();
 
         let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;


### PR DESCRIPTION
## Summary

Three `require_auth()` calls in `RewardManager` were wrapped in `#[cfg(not(test))]`, causing auth paths to be completely skipped during tests. A production auth bug could ship undetected.

**Affected functions:**
- `create_reward_pool` — `creator.require_auth()`
- `fund_reward_pool` — `funder.require_auth()`
- `admin_withdraw_unclaimed` — `admin.require_auth()`

## Fix

Removed all three `#[cfg(not(test))]` gates. No test changes were required — tests already call `env.mock_all_auths_allowing_non_root_auth()`, which satisfies `require_auth()` via Soroban's mock auth system.

Closes #81