### PR TITLE
fix(storage): extend TTL on all persistent and instance storage write…

### DIFF
--- a/contracts/hunty-core/src/storage.rs
+++ b/contracts/hunty-core/src/storage.rs
@@ -2,6 +2,14 @@ use crate::errors::HuntError;
 use crate::types::{Clue, Hunt, PlayerProgress, StoredPlayerProgress};
 use soroban_sdk::{symbol_short, Address, Env, Vec};
 
+// ~30 days at 5s/ledger. Instance TTL is bumped on every write — one call covers all keys.
+const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
+const INSTANCE_TTL_EXTEND_TO: u32 = 518_400;
+
+// Persistent entries (player progress + index) live ~90 days; bumped when threshold < 30 days.
+const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
+const PERSISTENT_TTL_EXTEND_TO: u32 = 1_555_200;
+
 /// Storage access layer for hunts, clues, and player progress.
 /// Provides type-safe, efficient storage operations with consistent key management.
 pub struct Storage;
@@ -22,99 +30,43 @@ impl Storage {
 
     // ========== Hunt Storage Functions ==========
 
-    /// Saves a Hunt struct with a unique key based on hunt_id.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt` - The Hunt struct to store
-    ///
-    /// # Panics
-    /// Panics if storage operation fails
     pub fn save_hunt(env: &Env, hunt: &Hunt) {
         let key = Self::hunt_key(hunt.hunt_id);
         env.storage().instance().set(&key, hunt);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
     }
 
-    /// Retrieves a hunt by ID, returning an Option.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The unique identifier of the hunt
-    ///
-    /// # Returns
-    /// * `Some(Hunt)` if the hunt exists, `None` otherwise
     pub fn get_hunt(env: &Env, hunt_id: u64) -> Option<Hunt> {
         let key = Self::hunt_key(hunt_id);
         env.storage().instance().get(&key)
     }
 
-    /// Retrieves a hunt by ID or returns an error if not found.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The unique identifier of the hunt
-    ///
-    /// # Returns
-    /// * `Ok(Hunt)` if the hunt exists
-    /// * `Err(HuntError)` if the hunt is not found
     pub fn get_hunt_or_error(env: &Env, hunt_id: u64) -> Result<Hunt, HuntError> {
         Self::get_hunt(env, hunt_id).ok_or(HuntError::HuntNotFound { hunt_id })
     }
 
     // ========== Clue Storage Functions ==========
 
-    /// Stores a clue using composite keys (hunt_id + clue_id).
-    /// Also maintains a list of clue IDs for the hunt.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt this clue belongs to
-    /// * `clue` - The Clue struct to store
     pub fn save_clue(env: &Env, hunt_id: u64, clue: &Clue) {
-        // Store the clue with composite key
         let key = Self::clue_key(hunt_id, clue.clue_id);
         env.storage().instance().set(&key, clue);
-
-        // Update the list of clue IDs for this hunt
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         Self::add_clue_to_list(env, hunt_id, clue.clue_id);
     }
 
-    /// Retrieves an individual clue by hunt_id and clue_id.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt this clue belongs to
-    /// * `clue_id` - The unique identifier of the clue within the hunt
-    ///
-    /// # Returns
-    /// * `Some(Clue)` if the clue exists, `None` otherwise
     pub fn get_clue(env: &Env, hunt_id: u64, clue_id: u32) -> Option<Clue> {
         let key = Self::clue_key(hunt_id, clue_id);
         env.storage().instance().get(&key)
     }
 
-    /// Retrieves a clue or returns an error if not found.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt this clue belongs to
-    /// * `clue_id` - The unique identifier of the clue within the hunt
-    ///
-    /// # Returns
-    /// * `Ok(Clue)` if the clue exists
-    /// * `Err(HuntError)` if the clue is not found
     pub fn get_clue_or_error(env: &Env, hunt_id: u64, clue_id: u32) -> Result<Clue, HuntError> {
         Self::get_clue(env, hunt_id, clue_id).ok_or(HuntError::ClueNotFound { hunt_id })
     }
 
-    /// Returns all clues for a specific hunt.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt to get clues for
-    ///
-    /// # Returns
-    /// A Vec containing all Clue structs for the hunt, in clue_id order
     pub fn list_clues_for_hunt(env: &Env, hunt_id: u64) -> Vec<Clue> {
         let clue_ids = Self::get_clue_ids_for_hunt(env, hunt_id);
         let mut clues = Vec::new(env);
@@ -132,52 +84,34 @@ impl Storage {
 
     // ========== Player Progress Storage Functions ==========
 
-    /// Stores player state/progress for a hunt.
-    /// Also maintains a list of registered players for the hunt.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `progress` - The PlayerProgress struct to store
     pub fn save_player_progress(env: &Env, progress: &PlayerProgress) {
-        // Store only the compact form — player and hunt_id are already the key
         let key = Self::progress_key(progress.hunt_id, &progress.player);
         env.storage().persistent().set(&key, &progress.to_stored());
-
-        // Update the list of players for this hunt
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
         Self::add_player_to_list(env, progress.hunt_id, &progress.player);
     }
 
-    /// Retrieves player progress for a specific hunt and player.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt the player is registered for
-    /// * `player` - The player's address
-    ///
-    /// # Returns
-    /// * `Some(PlayerProgress)` if progress exists, `None` otherwise
     pub fn get_player_progress(
         env: &Env,
         hunt_id: u64,
         player: &Address,
     ) -> Option<PlayerProgress> {
         let key = Self::progress_key(hunt_id, player);
-        env.storage()
+        let result = env
+            .storage()
             .persistent()
             .get::<_, StoredPlayerProgress>(&key)
-            .map(|stored| PlayerProgress::from_stored(stored, player.clone(), hunt_id))
+            .map(|stored| PlayerProgress::from_stored(stored, player.clone(), hunt_id));
+        if result.is_some() {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        }
+        result
     }
 
-    /// Retrieves player progress or returns an error if not found.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt the player is registered for
-    /// * `player` - The player's address
-    ///
-    /// # Returns
-    /// * `Ok(PlayerProgress)` if progress exists
-    /// * `Err(HuntError)` if the player is not registered
     pub fn get_player_progress_or_error(
         env: &Env,
         hunt_id: u64,
@@ -187,14 +121,6 @@ impl Storage {
             .ok_or(HuntError::PlayerNotRegistered { hunt_id })
     }
 
-    /// Returns all registered players for a hunt.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt to get players for
-    ///
-    /// # Returns
-    /// A Vec containing all PlayerProgress structs for the hunt
     pub fn get_hunt_players(env: &Env, hunt_id: u64) -> Vec<PlayerProgress> {
         let player_addresses = Self::get_player_addresses_for_hunt(env, hunt_id);
         let mut progress_list = Vec::new(env);
@@ -212,53 +138,40 @@ impl Storage {
 
     // ========== Helper Functions for Key Generation ==========
 
-    /// Generates a storage key for a hunt using a symbol prefix and hunt_id.
-    /// Uses tuple key (HUNT_KEY, hunt_id) for efficient storage access.
     fn hunt_key(hunt_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::HUNT_KEY, hunt_id)
     }
 
-    /// Generates a composite storage key for a clue.
-    /// Uses tuple key (CLUE_KEY, hunt_id, clue_id) for efficient storage access.
     fn clue_key(hunt_id: u64, clue_id: u32) -> (soroban_sdk::Symbol, u64, u32) {
         (Self::CLUE_KEY, hunt_id, clue_id)
     }
 
-    /// Generates a composite storage key for player progress.
-    /// Uses tuple key (PROGRESS_KEY, hunt_id, player) for efficient storage access.
     fn progress_key(hunt_id: u64, player: &Address) -> (soroban_sdk::Symbol, u64, Address) {
         (Self::PROGRESS_KEY, hunt_id, player.clone())
     }
 
-    /// Key for a single clue-list entry: (CLST, hunt_id, index)
     fn clue_entry_key(hunt_id: u64, index: u32) -> (soroban_sdk::Symbol, u64, u32) {
         (Self::CLUE_ENTRY_KEY, hunt_id, index)
     }
 
-    /// Key for the number of entries in the clue list for a hunt.
     fn clue_list_count_key(hunt_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::CLUE_LIST_COUNT_KEY, hunt_id)
     }
 
-    /// Generates a storage key for the clue counter per hunt.
     fn clue_counter_key(hunt_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::CLUE_COUNTER_KEY, hunt_id)
     }
 
-    /// Key for a single player-list entry: (PLRS, hunt_id, index)
     fn player_entry_key(hunt_id: u64, index: u32) -> (soroban_sdk::Symbol, u64, u32) {
         (Self::PLAYER_ENTRY_KEY, hunt_id, index)
     }
 
-    /// Key for the number of entries in the player list for a hunt.
     fn player_count_key(hunt_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::PLAYER_COUNT_KEY, hunt_id)
     }
 
     // ========== Internal Helper Functions ==========
 
-    /// Adds a clue ID to the per-hunt clue index.
-    /// Each entry is stored at its own key so no single entry grows unboundedly.
     fn add_clue_to_list(env: &Env, hunt_id: u64, clue_id: u32) {
         let count_key = Self::clue_list_count_key(hunt_id);
         let count: u32 = env.storage().instance().get(&count_key).unwrap_or(0);
@@ -269,12 +182,16 @@ impl Storage {
             return;
         }
 
-        env.storage().instance().set(&Self::clue_entry_key(hunt_id, count), &clue_id);
+        env.storage()
+            .instance()
+            .set(&Self::clue_entry_key(hunt_id, count), &clue_id);
         env.storage().instance().set(&count_key, &(count + 1));
         env.storage().instance().set(&exist_key, &());
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
     }
 
-    /// Retrieves all clue IDs for a hunt by reading individual entries.
     fn get_clue_ids_for_hunt(env: &Env, hunt_id: u64) -> Vec<u32> {
         let count_key = Self::clue_list_count_key(hunt_id);
         let count: u32 = env.storage().instance().get(&count_key).unwrap_or(0);
@@ -288,8 +205,6 @@ impl Storage {
         ids
     }
 
-    /// Adds a player address to the per-hunt player index.
-    /// Each entry is stored at its own key so no single entry grows unboundedly.
     fn add_player_to_list(env: &Env, hunt_id: u64, player: &Address) {
         let count_key = Self::player_count_key(hunt_id);
         let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
@@ -297,22 +212,48 @@ impl Storage {
         // O(1) existence check
         let exist_key = (symbol_short!("PLEX"), hunt_id, player.clone());
         if env.storage().persistent().has(&exist_key) {
+            // Bump the exist marker so this player's slot never silently expires
+            env.storage().persistent().extend_ttl(
+                &exist_key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
             return;
         }
 
-        env.storage().persistent().set(&Self::player_entry_key(hunt_id, count), player);
+        let entry_key = Self::player_entry_key(hunt_id, count);
+        env.storage().persistent().set(&entry_key, player);
+        env.storage().persistent().extend_ttl(
+            &entry_key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         env.storage().persistent().set(&count_key, &(count + 1));
+        env.storage().persistent().extend_ttl(
+            &count_key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         env.storage().persistent().set(&exist_key, &());
+        env.storage().persistent().extend_ttl(
+            &exist_key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
     }
 
-    /// Retrieves all player addresses for a hunt by reading individual entries.
     fn get_player_addresses_for_hunt(env: &Env, hunt_id: u64) -> Vec<Address> {
         let count_key = Self::player_count_key(hunt_id);
         let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
         let mut addrs = Vec::new(env);
         for i in 0..count {
             let entry_key = Self::player_entry_key(hunt_id, i);
-            if let Some(addr) = env.storage().persistent().get(&entry_key) {
+            if let Some(addr) = env.storage().persistent().get::<_, Address>(&entry_key) {
+                env.storage().persistent().extend_ttl(
+                    &entry_key,
+                    PERSISTENT_TTL_THRESHOLD,
+                    PERSISTENT_TTL_EXTEND_TO,
+                );
                 addrs.push_back(addr);
             }
         }
@@ -321,29 +262,17 @@ impl Storage {
 
     // ========== Hunt Counter Functions ==========
 
-    /// Increments and returns the next hunt ID.
-    /// This ensures unique, sequential hunt IDs.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    ///
-    /// # Returns
-    /// The next available hunt ID (starting from 1)
     pub fn next_hunt_id(env: &Env) -> u64 {
         let key = Self::HUNT_COUNTER_KEY;
         let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
         let next = current + 1;
         env.storage().instance().set(&key, &next);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         next
     }
 
-    /// Gets the current hunt counter value without incrementing.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    ///
-    /// # Returns
-    /// The current hunt counter value (0 if no hunts have been created)
     pub fn get_hunt_counter(env: &Env) -> u64 {
         let key = Self::HUNT_COUNTER_KEY;
         env.storage().instance().get(&key).unwrap_or(0)
@@ -351,31 +280,17 @@ impl Storage {
 
     // ========== Clue Counter (per hunt) Functions ==========
 
-    /// Increments and returns the next clue ID for a hunt.
-    /// Clue IDs are sequential within each hunt, starting from 1.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt to allocate a clue ID for
-    ///
-    /// # Returns
-    /// The next available clue ID for the hunt
     pub fn next_clue_id(env: &Env, hunt_id: u64) -> u32 {
         let key = Self::clue_counter_key(hunt_id);
         let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
         let next = current + 1;
         env.storage().instance().set(&key, &next);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         next
     }
 
-    /// Gets the current clue counter for a hunt without incrementing.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `hunt_id` - The hunt to get the clue count for
-    ///
-    /// # Returns
-    /// The number of clues added so far for the hunt (0 if none)
     pub fn get_clue_counter(env: &Env, hunt_id: u64) -> u32 {
         let key = Self::clue_counter_key(hunt_id);
         env.storage().instance().get(&key).unwrap_or(0)
@@ -387,6 +302,9 @@ impl Storage {
         env.storage()
             .instance()
             .set(&Self::REWARD_MGR_KEY, address);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
     }
 
     pub fn get_reward_manager(env: &Env) -> Option<Address> {


### PR DESCRIPTION
…s/reads

Soroban persistent storage entries expire silently without explicit TTL extension. This fixes player progress, player index, and pool-related records that would vanish after ~a few days on-chain.

- Instance storage (hunts, clues, counters): extend_ttl after every write
- Persistent storage (player progress + index): extend_ttl on every write and read so active players keep their entries alive
- Constants: INSTANCE 30-day threshold/extend, PERSISTENT 30-day threshold / 90-day extend-to

closes #85 