### PR TITLE
test: prevent adding clues to an active hunt

### DIFF
--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -794,6 +794,41 @@ mod test {
     }
 
     #[test]
+    fn test_add_clue_after_activation_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Hunt");
+        let description = String::from_str(&env, "Desc");
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let err = with_core_contract(&env, |env, _cid| {
+            let hid = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title,
+                description,
+                None,
+                None,
+            )
+            .unwrap();
+
+            // Add a required clue to allow activation
+            HuntyCore::add_clue(env.clone(), hid, question.clone(), answer.clone(), 1, true).unwrap();
+
+            // Activate the hunt
+            HuntyCore::activate_hunt(env.clone(), hid, creator.clone()).unwrap();
+
+            // Attempt to add a clue after activation (should fail)
+            HuntyCore::add_clue(env.clone(), hid, question, answer, 1, false).unwrap_err()
+        });
+
+        assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+    }
+
+    #[test]
     fn test_add_clue_invalid_question_too_long() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);


### PR DESCRIPTION
## What This Does
Adds a new unit test `test_add_clue_after_activation_fails` to the `HuntyCore` contract. The test verifies that attempting to add a clue to a hunt after it has already been activated correctly returns an `InvalidHuntStatus` error.

## Why
We need to lock in the Draft-only invariant for hunt modifications. While we previously tested the status check by manually altering storage, this new test exercises the actual lifecycle flow (create -> add required clue -> activate -> attempt to add another clue) to guarantee the contract behaves securely and as expected when users interact with it.

## Testing
- ✅ Added `test_add_clue_after_activation_fails` in `contracts/hunty-core/src/test.rs`
- ✅ Ran `make test` locally to ensure all unit tests pass

## Related Issues
Closes #182
