### PR TITLE
fix(#94): replace unbounded player scan in get_hunt_statistics with running counters

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -626,6 +626,7 @@ impl HuntyCore {
 
         let progress = PlayerProgress::new(&env, player.clone(), hunt_id, current_time);
         Storage::save_player_progress(&env, &progress);
+        Storage::increment_total_players(&env, hunt_id);
 
         let event = PlayerRegisteredEvent {
             hunt_id,
@@ -713,8 +714,10 @@ impl HuntyCore {
         let all_required_completed =
             Self::check_all_required_clues_completed(&env, hunt_id, &progress);
 
+        let just_completed = all_required_completed && !progress.is_completed;
+
         // If all required clues completed, mark hunt as completed for this player
-        if all_required_completed && !progress.is_completed {
+        if just_completed {
             progress.is_completed = true;
             progress.completed_at = current_time;
 
@@ -732,6 +735,9 @@ impl HuntyCore {
         }
 
         Storage::save_player_progress(&env, &progress);
+        if just_completed {
+            Storage::increment_completed(&env, hunt_id, progress.total_score);
+        }
 
         let clue_completed_event = ClueCompletedEvent {
             hunt_id,
@@ -904,17 +910,8 @@ impl HuntyCore {
         hunt_id: u64,
     ) -> Result<HuntStatistics, HuntErrorCode> {
         let _ = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
-        let players = Storage::get_hunt_players(&env, hunt_id);
-        let total_players = players.len() as u32;
-        let mut completed_count: u32 = 0;
-        let mut total_score_sum: u64 = 0;
-        for i in 0..players.len() {
-            let p = players.get(i).unwrap();
-            if p.is_completed {
-                completed_count += 1;
-            }
-            total_score_sum += p.total_score as u64;
-        }
+        let (total_players, completed_count, total_score_sum) =
+            Storage::get_hunt_stats(&env, hunt_id);
         let completion_rate_percent = if total_players > 0 {
             (completed_count * 100) / total_players
         } else {

--- a/contracts/hunty-core/src/storage.rs
+++ b/contracts/hunty-core/src/storage.rs
@@ -19,6 +19,7 @@ impl Storage {
     const HUNT_COUNTER_KEY: soroban_sdk::Symbol = symbol_short!("CNTR");
     const CLUE_COUNTER_KEY: soroban_sdk::Symbol = symbol_short!("CCNT");
     const REWARD_MGR_KEY: soroban_sdk::Symbol = symbol_short!("RWDMGR");
+    const HUNT_STATS_KEY: soroban_sdk::Symbol = symbol_short!("HSTATS");
 
     // ========== Hunt Storage Functions ==========
 
@@ -391,5 +392,37 @@ impl Storage {
 
     pub fn get_reward_manager(env: &Env) -> Option<Address> {
         env.storage().instance().get(&Self::REWARD_MGR_KEY)
+    }
+
+    // ========== Hunt Running Counters ==========
+
+    fn hunt_stats_key(hunt_id: u64) -> (soroban_sdk::Symbol, u64) {
+        (Self::HUNT_STATS_KEY, hunt_id)
+    }
+
+    /// Atomically increments the total_players counter for a hunt.
+    pub fn increment_total_players(env: &Env, hunt_id: u64) {
+        let key = Self::hunt_stats_key(hunt_id);
+        let (total, completed, score): (u32, u32, u64) =
+            env.storage().persistent().get(&key).unwrap_or((0, 0, 0));
+        env.storage()
+            .persistent()
+            .set(&key, &(total + 1, completed, score));
+    }
+
+    /// Atomically increments completed_count and adds `score` to total_score_sum.
+    pub fn increment_completed(env: &Env, hunt_id: u64, score: u32) {
+        let key = Self::hunt_stats_key(hunt_id);
+        let (total, completed, score_sum): (u32, u32, u64) =
+            env.storage().persistent().get(&key).unwrap_or((0, 0, 0));
+        env.storage()
+            .persistent()
+            .set(&key, &(total, completed + 1, score_sum + score as u64));
+    }
+
+    /// Returns (total_players, completed_count, total_score_sum) for a hunt.
+    pub fn get_hunt_stats(env: &Env, hunt_id: u64) -> (u32, u32, u64) {
+        let key = Self::hunt_stats_key(hunt_id);
+        env.storage().persistent().get(&key).unwrap_or((0, 0, 0))
     }
 }

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1350,7 +1350,7 @@ mod test {
                 HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
 
-            Ok(())
+            Ok::<(), HuntErrorCode>(())
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes #94.

`get_hunt_statistics` previously called `Storage::get_hunt_players`, which loads every `PlayerProgress` record from persistent storage. With thousands of players this could hit gas limits.

## Changes

**`storage.rs`**
- Added `HUNT_STATS_KEY` constant
- Added `increment_total_players(env, hunt_id)` — called on each registration
- Added `increment_completed(env, hunt_id, score)` — called when a player newly completes a hunt
- Added `get_hunt_stats(env, hunt_id) -> (u32, u32, u64)` — reads `(total_players, completed_count, total_score_sum)` in O(1)

**`lib.rs`**
- `register_player`: calls `Storage::increment_total_players` after saving progress
- `submit_answer`: introduces `just_completed` flag; calls `Storage::increment_completed` when a player is newly completing the hunt (guards against double-counting on re-submission)
- `get_hunt_statistics`: rewrites the scan loop as a single `Storage::get_hunt_stats` call — now O(1) regardless of player count

**`test.rs`**
- Fixed pre-existing `E0282` type annotation error (`Ok(())` → `Ok::<(), HuntErrorCode>(())`)

## Testing

All 3 `get_hunt_statistics` tests pass:
- `test_get_hunt_statistics_hunt_not_found`
- `test_get_hunt_statistics_empty_players`
- `test_get_hunt_statistics_aggregates_correctly`

The 6 pre-existing failures (`Error(Auth, ExistingValue)`) are unrelated to this change and existed on `main` before this PR.