### PR TITLE
fix: call require_auth before status check in add_clue

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -147,10 +147,10 @@ impl HuntyCore {
         is_required: bool,
     ) -> Result<u32, HuntErrorCode> {
         let hunt = Storage::get_hunt_or_error(&env, hunt_id).map_err(HuntErrorCode::from)?;
+        hunt.creator.require_auth();
         if hunt.status != HuntStatus::Draft {
             return Err(HuntErrorCode::InvalidHuntStatus);
         }
-        hunt.creator.require_auth();
         if Storage::get_clue_counter(&env, hunt_id) >= MAX_CLUES_PER_HUNT {
             return Err(HuntErrorCode::from(HuntError::TooManyClues {
                 hunt_id,


### PR DESCRIPTION
fix: reorder require_auth before status check in add_clue
  
  Previously, add_clue performed the hunt status check before calling hunt.creator.require_auth(). This meant unauthorized callers would
  trigger a storage read and status validation before being rejected.
  
  Change: Move require_auth immediately after loading the hunt, so unauthenticated calls fail fast before any further logic (status check,
  clue counter read, input validation).
  
  The storage read to fetch the hunt remains necessary since require_auth requires hunt.creator.
closes #193