### PR TITLE
feat: add Paused status to HuntStatus, replace Draft in deactivate_hu…

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -266,7 +266,8 @@ impl HuntyCore {
             return Err(HuntErrorCode::Unauthorized);
         }
 
-        if hunt.status != HuntStatus::Draft {
+        // Allow re-activation from Paused (issue #91) as well as initial activation from Draft.
+        if hunt.status != HuntStatus::Draft && hunt.status != HuntStatus::Paused {
             return Err(HuntErrorCode::InvalidHuntStatus);
         }
 
@@ -309,7 +310,9 @@ impl HuntyCore {
             return Err(HuntErrorCode::InvalidHuntStatus);
         }
 
-        hunt.status = HuntStatus::Draft;
+        // Issue #91: use Paused, not Draft, so a temporarily stopped hunt
+        // is distinguishable from one that was never activated.
+        hunt.status = HuntStatus::Paused;
 
         Storage::save_hunt(&env, &hunt);
 
@@ -390,7 +393,8 @@ impl HuntyCore {
             HuntStatus::Draft
             | HuntStatus::Active
             | HuntStatus::Completed
-            | HuntStatus::Cancelled => {}
+            | HuntStatus::Cancelled
+            | HuntStatus::Paused => {}
         }
 
         // Return the full Hunt struct

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -973,11 +973,142 @@ mod test {
             // Activate hunt
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
 
-            // Deactivate hunt
+            // Deactivate hunt — status must be Paused, not Draft (issue #91).
             HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
 
             let hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            assert_eq!(hunt.status, HuntStatus::Draft);
+            assert_eq!(hunt.status, HuntStatus::Paused);
+        });
+    }
+
+    // ── Issue #91: Paused-state tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_deactivate_sets_paused_not_draft() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            let hunt = Storage::get_hunt(env, hunt_id).unwrap();
+            assert_eq!(hunt.status, HuntStatus::Paused);
+            assert_ne!(hunt.status, HuntStatus::Draft);
+        });
+    }
+
+    #[test]
+    fn test_reactivate_from_paused_succeeds() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            let hunt = Storage::get_hunt(env, hunt_id).unwrap();
+            assert_eq!(hunt.status, HuntStatus::Active);
+        });
+    }
+
+    #[test]
+    fn test_deactivate_draft_hunt_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            // Hunt is Draft — deactivate must reject it.
+            let err = HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap_err();
+            assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+        });
+    }
+
+    #[test]
+    fn test_cannot_add_clue_to_paused_hunt() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question.clone(), answer.clone(), 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            let err = HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, false).unwrap_err();
+            assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+        });
+    }
+
+    #[test]
+    fn test_register_player_blocked_when_paused() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            let err = HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
+            assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+        });
+    }
+
+    #[test]
+    fn test_cancel_from_paused_succeeds() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        with_core_contract(&env, |env, _cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(), creator.clone(),
+                String::from_str(env, "Hunt"), String::from_str(env, "Desc"), None, None,
+            ).unwrap();
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::cancel_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            let hunt = Storage::get_hunt(env, hunt_id).unwrap();
+            assert_eq!(hunt.status, HuntStatus::Cancelled);
         });
     }
 

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -7,6 +7,11 @@ pub enum HuntStatus {
     Active,
     Completed,
     Cancelled,
+    /// Hunt was active but the creator temporarily stopped it.
+    /// Distinct from Draft (never activated) so re-registration logic and
+    /// UIs can unambiguously communicate "this hunt is paused, not new".
+    /// Valid transitions: Paused → Active (re-activate), Paused → Cancelled.
+    Paused,
 }
 
 #[contracttype]


### PR DESCRIPTION
…nt (#91)

Previously deactivate_hunt reset a hunt to Draft, conflating 'never activated' with 'temporarily stopped'. This patch:

- Adds HuntStatus::Paused to the enum so the two states are always distinguishable on-chain and in UIs.
- deactivate_hunt now transitions Active → Paused instead of Active → Draft.
- activate_hunt accepts both Draft and Paused as valid source states so creators can resume a paused hunt without re-creating it.
- get_hunt_info exhaustive match updated to cover Paused.
- add_clue continues to require Draft status only — clues cannot be added to a Paused hunt, preventing mid-pause configuration changes that would confuse registered players.

Tests added:
- deactivate_sets_paused_not_draft
- reactivate_from_paused_succeeds
- deactivate_draft_hunt_fails (Draft → deactivate must reject)
- cannot_add_clue_to_paused_hunt
- register_player_blocked_when_paused
- cancel_from_paused_succeeds

Existing test_deactivate_hunt_success updated: asserts Paused.