### PR TITLE
feat(nft-reward): add initialize entry point with admin, minter whitelist, and max supply

### DIFF
--- a/contracts/nft-reward/src/errors.rs
+++ b/contracts/nft-reward/src/errors.rs
@@ -9,4 +9,6 @@ pub enum NftErrorCode {
     NotOwner = 3,
     InvalidRecipient = 4,
     SoulboundNft = 5,
+    AlreadyInitialized = 6,
+    MaxSupplyReached = 7,
 }

--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -86,10 +86,68 @@ pub struct NftReward;
 
 #[contractimpl]
 impl NftReward {
+    /// One-time setup: stores the admin, registers the first authorized minter, and
+    /// optionally caps total supply.  Must be called before minting on an initialized
+    /// contract; subsequent calls are rejected with `AlreadyInitialized`.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        authorized_minter: Address,
+        max_supply: Option<u64>,
+    ) -> Result<(), crate::errors::NftErrorCode> {
+        if Storage::is_initialized(&env) {
+            return Err(crate::errors::NftErrorCode::AlreadyInitialized);
+        }
+        admin.require_auth();
+        Storage::save_admin(&env, &admin);
+        Storage::add_minter(&env, &authorized_minter);
+        Storage::save_max_supply(&env, max_supply);
+        Ok(())
+    }
+
+    /// Returns the stored admin address, or `None` if the contract is not yet initialized.
+    pub fn get_admin(env: Env) -> Option<Address> {
+        Storage::get_admin(&env)
+    }
+
+    /// Adds a new address to the minter whitelist.  Admin only.
+    pub fn add_minter(
+        env: Env,
+        admin: Address,
+        new_minter: Address,
+    ) -> Result<(), crate::errors::NftErrorCode> {
+        admin.require_auth();
+        let stored = Storage::get_admin(&env).ok_or(crate::errors::NftErrorCode::Unauthorized)?;
+        if admin != stored {
+            return Err(crate::errors::NftErrorCode::Unauthorized);
+        }
+        Storage::add_minter(&env, &new_minter);
+        Ok(())
+    }
+
+    /// Removes an address from the minter whitelist.  Admin only.
+    pub fn remove_minter(
+        env: Env,
+        admin: Address,
+        minter: Address,
+    ) -> Result<(), crate::errors::NftErrorCode> {
+        admin.require_auth();
+        let stored = Storage::get_admin(&env).ok_or(crate::errors::NftErrorCode::Unauthorized)?;
+        if admin != stored {
+            return Err(crate::errors::NftErrorCode::Unauthorized);
+        }
+        Storage::remove_minter(&env, &minter);
+        Ok(())
+    }
+
     /// Mints a unique NFT as a reward for hunt completion.
     ///
+    /// `minter` must be an authorized minter (and must sign the transaction) when the
+    /// contract has been initialized.  Before initialization the check is skipped so
+    /// that existing deployments remain functional.
+    ///
     /// # Arguments
-    /// * `env` - The Soroban environment
+    /// * `minter` - Address performing the mint (must be whitelisted after init)
     /// * `hunt_id` - The hunt this NFT commemorates
     /// * `player_address` - The address of the player completing the hunt (initial owner)
     /// * `metadata` - NFT metadata (title, description, image URI, hunt_title, rarity, tier)
@@ -98,10 +156,22 @@ impl NftReward {
     /// The unique NFT ID of the minted NFT
     pub fn mint_reward_nft(
         env: Env,
+        minter: Address,
         hunt_id: u64,
         player_address: Address,
         metadata: NftMetadata,
     ) -> u64 {
+        if Storage::is_initialized(&env) {
+            minter.require_auth();
+            if !Storage::is_minter(&env, &minter) {
+                panic!("unauthorized minter");
+            }
+            if let Some(max) = Storage::get_max_supply(&env) {
+                if Storage::get_nft_counter(&env) >= max {
+                    panic!("max supply reached");
+                }
+            }
+        }
         let minted_at = env.ledger().timestamp();
 
         let nft_id = Storage::next_nft_id(&env);
@@ -135,6 +205,9 @@ impl NftReward {
     /// used by cross-contract callers (e.g. RewardManager) that cannot depend
     /// on this crate's `NftMetadata` type directly.
     ///
+    /// `minter` is the calling contract's address and must be whitelisted when the
+    /// contract has been initialized.
+    ///
     /// Expected keys in `metadata` (all optional, with sensible defaults):
     /// - "title": String
     /// - "description": String
@@ -144,6 +217,7 @@ impl NftReward {
     /// - "tier": u32
     pub fn mint_reward_nft_from_map(
         env: Env,
+        minter: Address,
         hunt_id: u64,
         player_address: Address,
         metadata: Map<Symbol, Val>,
@@ -189,7 +263,7 @@ impl NftReward {
             tier,
         };
 
-        Self::mint_reward_nft(env, hunt_id, player_address, meta)
+        Self::mint_reward_nft(env, minter, hunt_id, player_address, meta)
     }
 
     /// Retrieves NFT data by ID.

--- a/contracts/nft-reward/src/storage.rs
+++ b/contracts/nft-reward/src/storage.rs
@@ -8,6 +8,9 @@ impl Storage {
     const NFT_KEY: soroban_sdk::Symbol = symbol_short!("NFT");
     const NFT_COUNTER_KEY: soroban_sdk::Symbol = symbol_short!("CNTR");
     const OWNER_NFTS_KEY: soroban_sdk::Symbol = symbol_short!("ONFT");
+    const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("ADMIN");
+    const MAX_SUPPLY_KEY: soroban_sdk::Symbol = symbol_short!("MXSUP");
+    const MINTER_KEY: soroban_sdk::Symbol = symbol_short!("MINTER");
 
     fn nft_key(nft_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::NFT_KEY, nft_id)
@@ -15,6 +18,54 @@ impl Storage {
 
     fn owner_nfts_key(owner: &Address) -> (soroban_sdk::Symbol, Address) {
         (Self::OWNER_NFTS_KEY, owner.clone())
+    }
+
+    fn minter_key(minter: &Address) -> (soroban_sdk::Symbol, Address) {
+        (Self::MINTER_KEY, minter.clone())
+    }
+
+    // --- Admin / initialization ---
+
+    pub fn is_initialized(env: &Env) -> bool {
+        env.storage().instance().has(&Self::ADMIN_KEY)
+    }
+
+    pub fn save_admin(env: &Env, admin: &Address) {
+        env.storage().instance().set(&Self::ADMIN_KEY, admin);
+    }
+
+    pub fn get_admin(env: &Env) -> Option<Address> {
+        env.storage().instance().get(&Self::ADMIN_KEY)
+    }
+
+    // --- Max supply ---
+
+    /// Stores max supply. Passing None is a no-op (absence of the key means unlimited).
+    pub fn save_max_supply(env: &Env, max_supply: Option<u64>) {
+        if let Some(supply) = max_supply {
+            env.storage().instance().set(&Self::MAX_SUPPLY_KEY, &supply);
+        }
+    }
+
+    pub fn get_max_supply(env: &Env) -> Option<u64> {
+        env.storage().instance().get(&Self::MAX_SUPPLY_KEY)
+    }
+
+    // --- Minter whitelist ---
+
+    pub fn add_minter(env: &Env, minter: &Address) {
+        let key = Self::minter_key(minter);
+        env.storage().persistent().set(&key, &true);
+    }
+
+    pub fn remove_minter(env: &Env, minter: &Address) {
+        let key = Self::minter_key(minter);
+        env.storage().persistent().remove(&key);
+    }
+
+    pub fn is_minter(env: &Env, minter: &Address) -> bool {
+        let key = Self::minter_key(minter);
+        env.storage().persistent().get(&key).unwrap_or(false)
     }
 
     /// Saves an NFT to persistent storage.

--- a/contracts/nft-reward/src/test.rs
+++ b/contracts/nft-reward/src/test.rs
@@ -14,6 +14,17 @@ fn setup_env() -> Env {
     env
 }
 
+/// Returns (env, contract_id, admin, minter) with the contract initialized.
+fn setup_initialized() -> (Env, Address, Address, Address) {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, NftReward);
+    let client = NftRewardClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let minter = Address::generate(&env);
+    client.initialize(&admin, &minter, &None);
+    (env, contract_id, admin, minter)
+}
+
 fn create_metadata(env: &Env, title: &str, desc: &str, image_uri: &str) -> NftMetadata {
     NftMetadata {
         title: String::from_str(env, title),
@@ -57,7 +68,7 @@ fn test_mint_reward_nft() {
         "ipfs://QmExample123",
     );
 
-    let nft_id = client.mint_reward_nft(&1, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &1, &player, &metadata);
 
     assert_eq!(nft_id, 1);
 
@@ -80,11 +91,11 @@ fn test_nft_ids_are_unique() {
     let player2 = Address::generate(&env);
     let metadata = create_metadata(&env, "NFT 1", "Desc 1", "ipfs://1");
 
-    let nft_id_1 = client.mint_reward_nft(&1, &player1, &metadata);
+    let nft_id_1 = client.mint_reward_nft(&player1, &1, &player1, &metadata);
     let metadata2 = create_metadata(&env, "NFT 2", "Desc 2", "ipfs://2");
-    let nft_id_2 = client.mint_reward_nft(&1, &player2, &metadata2);
+    let nft_id_2 = client.mint_reward_nft(&player2, &1, &player2, &metadata2);
     let metadata3 = create_metadata(&env, "NFT 3", "Desc 3", "ipfs://3");
-    let nft_id_3 = client.mint_reward_nft(&2, &player1, &metadata3);
+    let nft_id_3 = client.mint_reward_nft(&player1, &2, &player1, &metadata3);
 
     assert_eq!(nft_id_1, 1);
     assert_eq!(nft_id_2, 2);
@@ -104,7 +115,7 @@ fn test_metadata_stored_correctly() {
         "https://cdn.example.com/nft/123.png",
     );
 
-    let nft_id = client.mint_reward_nft(&42, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &42, &player, &metadata);
     let nft = client.get_nft(&nft_id).unwrap();
 
     assert_eq!(nft.metadata.title, String::from_str(&env, "Treasure Hunter Trophy"));
@@ -126,7 +137,7 @@ fn test_initial_ownership_set_correctly() {
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Trophy", "Trophy desc", "ipfs://trophy");
 
-    let nft_id = client.mint_reward_nft(&1, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &1, &player, &metadata);
 
     let owner = client.owner_of(&nft_id).unwrap();
     assert_eq!(owner, player);
@@ -143,7 +154,7 @@ fn test_nft_minted_event() {
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Event Test", "Event desc", "ipfs://event");
 
-    let _nft_id = client.mint_reward_nft(&7, &player, &metadata);
+    let _nft_id = client.mint_reward_nft(&player, &7, &player, &metadata);
 
     let events = env.events().all();
     assert!(!events.is_empty());
@@ -171,7 +182,7 @@ fn test_multiple_nfts_can_be_minted() {
 
     for i in 0..5 {
         let metadata = create_metadata(&env, titles[i], descs[i], uris[i]);
-        let nft_id = client.mint_reward_nft(&(i as u64 + 1), &player, &metadata);
+        let nft_id = client.mint_reward_nft(&player, &(i as u64 + 1), &player, &metadata);
         assert_eq!(nft_id, (i as u64) + 1);
     }
 
@@ -185,7 +196,7 @@ fn test_nft_data_can_be_queried() {
 
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Query Test", "Query desc", "ipfs://query");
-    let nft_id = client.mint_reward_nft(&99, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &99, &player, &metadata);
 
     let nft = client.get_nft(&nft_id);
     assert!(nft.is_some());
@@ -225,7 +236,7 @@ fn test_get_nft_metadata_returns_complete_info() {
         1, // tier 1
     );
 
-    let nft_id = client.mint_reward_nft(&42, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &42, &player, &metadata);
     let meta = client.get_nft_metadata(&nft_id).unwrap();
 
     assert_eq!(meta.nft_id, nft_id);
@@ -249,7 +260,7 @@ fn test_update_nft_metadata_owner_only() {
     let owner = Address::generate(&env);
     let metadata = create_metadata(&env, "Original", "Original desc", "ipfs://old");
 
-    let nft_id = client.mint_reward_nft(&1, &owner, &metadata);
+    let nft_id = client.mint_reward_nft(&owner, &1, &owner, &metadata);
 
     client.update_nft_metadata(
         &nft_id,
@@ -272,7 +283,7 @@ fn test_update_nft_metadata_preserves_immutable_fields() {
     let owner = Address::generate(&env);
     let metadata = create_metadata_full(&env, "Title", "Desc", "ipfs://img", "Hunt", 3, 2);
 
-    let nft_id = client.mint_reward_nft(&1, &owner, &metadata);
+    let nft_id = client.mint_reward_nft(&owner, &1, &owner, &metadata);
 
     client.update_nft_metadata(
         &nft_id,
@@ -298,7 +309,7 @@ fn test_transfer_nft_success() {
     let to = Address::generate(&env);
     let metadata = create_metadata(&env, "Transfer NFT", "Test transfer", "ipfs://transfer");
 
-    let nft_id = client.mint_reward_nft(&1, &from, &metadata);
+    let nft_id = client.mint_reward_nft(&from, &1, &from, &metadata);
     assert_eq!(client.owner_of(&nft_id), Some(from.clone()));
 
     client.transfer_nft(&nft_id, &from, &to);
@@ -320,8 +331,8 @@ fn test_transfer_nft_updates_player_nfts() {
     let metadata1 = create_metadata(&env, "NFT 1", "Desc 1", "ipfs://1");
     let metadata2 = create_metadata(&env, "NFT 2", "Desc 2", "ipfs://2");
 
-    let nft1 = client.mint_reward_nft(&1, &alice, &metadata1);
-    let nft2 = client.mint_reward_nft(&2, &alice, &metadata2);
+    let nft1 = client.mint_reward_nft(&alice, &1, &alice, &metadata1);
+    let nft2 = client.mint_reward_nft(&alice, &2, &alice, &metadata2);
 
     let alice_nfts = client.get_player_nfts(&alice);
     assert_eq!(alice_nfts.len(), 2);
@@ -350,9 +361,9 @@ fn test_transfer_nft_requires_auth() {
     let to = Address::generate(&env);
     let metadata = create_metadata(&env, "Auth Test", "Desc", "ipfs://auth");
 
-    let _nft_id = client.mint_reward_nft(&1, &from, &metadata);
+    let _nft_id = client.mint_reward_nft(&from, &1, &from, &metadata);
 
-    // This should fail - from has not authorized
+    // This should fail - from has not authorized the transfer
     client.transfer_nft(&1, &from, &to);
 }
 
@@ -379,7 +390,7 @@ fn test_transfer_nft_not_owner() {
     let to = Address::generate(&env);
     let metadata = create_metadata(&env, "Owner Test", "Desc", "ipfs://owner");
 
-    let nft_id = client.mint_reward_nft(&1, &owner, &metadata);
+    let nft_id = client.mint_reward_nft(&owner, &1, &owner, &metadata);
 
     // Attacker tries to transfer - with mock_all_auths they "auth" but NotOwner check fails
     client.transfer_nft(&nft_id, &attacker, &to);
@@ -394,7 +405,7 @@ fn test_transfer_nft_invalid_recipient_same_as_from() {
     let owner = Address::generate(&env);
     let metadata = create_metadata(&env, "Same Addr", "Desc", "ipfs://same");
 
-    let nft_id = client.mint_reward_nft(&1, &owner, &metadata);
+    let nft_id = client.mint_reward_nft(&owner, &1, &owner, &metadata);
 
     client.transfer_nft(&nft_id, &owner, &owner);
 }
@@ -408,7 +419,7 @@ fn test_transfer_nft_emits_event() {
     let to = Address::generate(&env);
     let metadata = create_metadata(&env, "Event NFT", "Desc", "ipfs://event");
 
-    let nft_id = client.mint_reward_nft(&1, &from, &metadata);
+    let nft_id = client.mint_reward_nft(&from, &1, &from, &metadata);
     client.transfer_nft(&nft_id, &from, &to);
 
     // Transfer succeeded; NftTransferred event is emitted by transfer_nft
@@ -433,8 +444,117 @@ fn test_get_nft_owner_matches_owner_of() {
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Alias Test", "Desc", "ipfs://alias");
 
-    let nft_id = client.mint_reward_nft(&1, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&player, &1, &player, &metadata);
 
     assert_eq!(client.owner_of(&nft_id), client.get_nft_owner(&nft_id));
     assert_eq!(client.get_nft_owner(&nft_id), Some(player));
+}
+
+// --- initialize / access-control tests ---
+
+#[test]
+fn test_initialize_stores_admin_and_minter() {
+    let (env, contract_id, admin, minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_admin(), Some(admin));
+
+    let player = Address::generate(&env);
+    let metadata = create_metadata(&env, "Init NFT", "Desc", "ipfs://init");
+    let nft_id = client.mint_reward_nft(&minter, &1, &player, &metadata);
+    assert_eq!(nft_id, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_rejects_double_init() {
+    let (env, contract_id, admin, minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &minter, &None);
+}
+
+#[test]
+#[should_panic]
+fn test_unauthorized_minter_rejected_after_init() {
+    let (env, contract_id, _admin, _minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    let rogue = Address::generate(&env);
+    let player = Address::generate(&env);
+    let metadata = create_metadata(&env, "Rogue NFT", "Desc", "ipfs://rogue");
+    client.mint_reward_nft(&rogue, &1, &player, &metadata);
+}
+
+#[test]
+fn test_add_minter_allows_new_minter() {
+    let (env, contract_id, admin, _original_minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    let new_minter = Address::generate(&env);
+    client.add_minter(&admin, &new_minter);
+
+    let player = Address::generate(&env);
+    let metadata = create_metadata(&env, "New Minter NFT", "Desc", "ipfs://new");
+    let nft_id = client.mint_reward_nft(&new_minter, &1, &player, &metadata);
+    assert_eq!(nft_id, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_remove_minter_revokes_access() {
+    let (env, contract_id, admin, minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    client.remove_minter(&admin, &minter);
+
+    let player = Address::generate(&env);
+    let metadata = create_metadata(&env, "Revoked NFT", "Desc", "ipfs://revoked");
+    client.mint_reward_nft(&minter, &1, &player, &metadata);
+}
+
+#[test]
+#[should_panic]
+fn test_add_minter_requires_admin() {
+    let (env, contract_id, _admin, _minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    let imposter = Address::generate(&env);
+    let new_minter = Address::generate(&env);
+    client.add_minter(&imposter, &new_minter);
+}
+
+#[test]
+#[should_panic]
+fn test_max_supply_enforced() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, NftReward);
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let minter = Address::generate(&env);
+    client.initialize(&admin, &minter, &Some(2));
+
+    let player = Address::generate(&env);
+    let m1 = create_metadata(&env, "NFT 1", "Desc", "ipfs://1");
+    let m2 = create_metadata(&env, "NFT 2", "Desc", "ipfs://2");
+    let m3 = create_metadata(&env, "NFT 3", "Desc", "ipfs://3");
+
+    client.mint_reward_nft(&minter, &1, &player, &m1);
+    client.mint_reward_nft(&minter, &2, &player, &m2);
+    // Third mint should panic — max supply is 2
+    client.mint_reward_nft(&minter, &3, &player, &m3);
+}
+
+#[test]
+fn test_no_max_supply_allows_unlimited_mints() {
+    let (env, contract_id, _admin, minter) = setup_initialized();
+    let client = NftRewardClient::new(&env, &contract_id);
+
+    let player = Address::generate(&env);
+    for i in 1u64..=5 {
+        let metadata = create_metadata(&env, "NFT", "Desc", "ipfs://x");
+        client.mint_reward_nft(&minter, &i, &player, &metadata);
+    }
+    assert_eq!(client.total_supply(), 5);
 }

--- a/contracts/reward-manager/src/nft_handler.rs
+++ b/contracts/reward-manager/src/nft_handler.rs
@@ -49,6 +49,7 @@ impl NftHandler {
         metadata.set(soroban_sdk::Symbol::new(env, "tier"), tier.into_val(env));
 
         let mut args = soroban_sdk::Vec::new(env);
+        args.push_back(env.current_contract_address().into_val(env));
         args.push_back(hunt_id.into_val(env));
         args.push_back(player.clone().into_val(env));
         args.push_back(metadata.into_val(env));


### PR DESCRIPTION
## Summary

- Adds `initialize(admin, authorized_minter, max_supply: Option<u64>)` one-time setup entry point to `NftReward`
- Stores admin address in instance storage; subsequent calls return `AlreadyInitialized`
- Seeds a minter whitelist in persistent storage with the first `authorized_minter`
- Optionally caps total supply — enforced on every mint once set
- `mint_reward_nft` and `mint_reward_nft_from_map` now accept a `minter: Address` parameter; after initialization the minter must be whitelisted and must sign the transaction
- Before initialization (undeployed or legacy contracts) minting behaviour is unchanged — backward compatible
- Adds `add_minter` / `remove_minter` (admin-only) for runtime whitelist management
- Adds `get_admin` read function
- Updates `nft_handler` in `reward-manager` to pass `env.current_contract_address()` as the minter for cross-contract minting to keep working after the NFT contract is initialized
- Adds new error codes `AlreadyInitialized = 6` and `MaxSupplyReached = 7`

Closes #196

## Test plan

- [ ] `test_initialize_stores_admin_and_minter` — admin stored, whitelisted minter can mint
- [ ] `test_initialize_rejects_double_init` — second init panics with `AlreadyInitialized`
- [ ] `test_unauthorized_minter_rejected_after_init` — non-whitelisted address panics
- [ ] `test_add_minter_allows_new_minter` — admin can expand whitelist
- [ ] `test_remove_minter_revokes_access` — revoked minter panics on next mint
- [ ] `test_add_minter_requires_admin` — non-admin cannot add minters
- [ ] `test_max_supply_enforced` — third mint panics when cap is 2
- [ ] `test_no_max_supply_allows_unlimited_mints` — `None` max supply imposes no cap
- [ ] All pre-existing tests continue to pass (uninitialised path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)