### PR TITLE
fix refund pool authorization

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -202,6 +202,9 @@ impl RewardManager {
         creator: Address,
         hunt_id: u64,
     ) -> Result<(), RewardErrorCode> {
+        #[cfg(not(test))]
+        creator.require_auth();
+
         let pool_config = Storage::get_pool_config(&env, hunt_id)
             .ok_or(RewardErrorCode::PoolNotFound)?;
         if creator != pool_config.creator {


### PR DESCRIPTION
Closes #80 

## Summary
- Adds `creator.require_auth()` to `refund_pool` so only the pool creator can authorize refunds.
- Keeps the existing `#[cfg(not(test))]` auth pattern used by nearby reward-manager entrypoints.

