### PR TITLE
feat: add windowed leaderboard scan with pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ The beauty of Hunty lies in its simplicity and security. Answers are hashed on-c
 
 ## Game Overview
 
+### Leaderboard notes
+
+- **Scan limitation**: For gas safety, the on-chain `get_hunt_leaderboard` query scans a bounded number of player records (default cap in contract). For very popular hunts with many registrations, use the new paginated API `get_hunt_leaderboard_window` to page through registered players in windows and merge results off-chain to build a full top-N leaderboard.
+
+
 ### The Big Picture
 
 Hunty operates as a three-contract system where each contract has a specific role:

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -847,6 +847,59 @@ impl HuntyCore {
         Ok(result)
     }
 
+    /// Scans a bounded window of registered players for a hunt and returns
+    /// their compact rows. This method enables clients to page through all
+    /// registered players in multiple calls (bounded by `MAX_LEADERBOARD_SCAN_SIZE`)
+    /// and merge results off-chain to build a full leaderboard without a single
+    /// large on-chain scan.
+    ///
+    /// Arguments:
+    /// * `env` - Soroban environment
+    /// * `hunt_id` - Hunt identifier
+    /// * `start_index` - Zero-based index into the registered players list to start scanning
+    /// * `window_size` - Number of player records to scan in this call (capped)
+    ///
+    /// Returns a `LeaderboardWindow` containing the scanned rows, the `next_index`
+    /// clients should use for the following call and a `finished` flag indicating
+    /// whether the end of the player list has been reached.
+    pub fn get_hunt_leaderboard_window(
+        env: Env,
+        hunt_id: u64,
+        start_index: u32,
+        window_size: u32,
+    ) -> Result<crate::types::LeaderboardWindow, HuntErrorCode> {
+        let _ = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
+        let queried_at = env.ledger().timestamp();
+        let players = Storage::get_hunt_players(&env, hunt_id);
+        let total_players = players.len();
+
+        let start = core::cmp::min(start_index as usize, total_players);
+        let capped_window = core::cmp::min(window_size, MAX_LEADERBOARD_SCAN_SIZE);
+        let end = core::cmp::min(start + capped_window as usize, total_players);
+
+        let mut rows = Vec::new(&env);
+        for i in start..end {
+            let p = players.get(i).unwrap();
+            rows.push_back(crate::types::LeaderboardRow {
+                index: i as u32,
+                player: p.player.clone(),
+                score: p.total_score,
+                completed_at: p.completed_at,
+                is_completed: p.is_completed,
+            });
+        }
+
+        let next_index = end as u32;
+        let finished = end >= total_players;
+
+        Ok(crate::types::LeaderboardWindow {
+            entries: rows,
+            next_index,
+            finished,
+            queried_at,
+        })
+    }
+
     /// Picks the index of the best entry not in `selected`. Order: score desc, then completed_at asc (0 = last).
     fn leaderboard_best_index(
         entries: &Vec<(Address, u32, u64, bool)>,

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -308,6 +308,31 @@ pub struct LeaderboardEntry {
     pub queried_at: u64,
 }
 
+/// Lightweight row returned when scanning a window of players. Includes the
+/// original player index so callers can merge/paginate results client-side.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LeaderboardRow {
+    pub index: u32,
+    pub player: Address,
+    pub score: u32,
+    pub completed_at: u64,
+    pub is_completed: bool,
+}
+
+/// Result of a single leaderboard scan window. Clients may call repeatedly
+/// with `next_index` until `finished` is true, merging `entries` off-chain to
+/// produce a global top-N leaderboard without requiring a single large on-chain
+/// scan (which would be expensive in gas).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LeaderboardWindow {
+    pub entries: Vec<LeaderboardRow>,
+    pub next_index: u32,
+    pub finished: bool,
+    pub queried_at: u64,
+}
+
 /// Aggregate statistics for a hunt (read-only query result).
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
The existing get_hunt_leaderboard did unbounded scans, which gets expensive fast on large participant sets. I added get_hunt_leaderboard_window(env, hunt_id, start_index, window_size) with a capped window size so clients can page through results in gas-safe chunks and merge off-chain. Existing function is untouched. README documents the limitation and the new API. 
Closed #164 