### PR TITLE
fix: add caller.require_auth() to deactivate_hunt

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -296,6 +296,8 @@ impl HuntyCore {
     }
 
     pub fn deactivate_hunt(env: Env, hunt_id: u64, caller: Address) -> Result<(), HuntErrorCode> {
+        caller.require_auth();
+
         // Load hunt
         let mut hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
 


### PR DESCRIPTION
Missing authorization check allowed any attacker to deactivate any hunt by supplying the creator address without a valid signature.

Closes #77