### PR TITLE
test: assert list_clues returns an empty vector

### DIFF
--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -620,16 +620,42 @@ mod test {
         env.ledger().set_timestamp(1_700_000_000);
         env.mock_all_auths();
         let creator = Address::generate(&env);
-        let title = String::from_str(&env, "Hunt");
-        let description = String::from_str(&env, "Desc");
 
         let list = with_core_contract(&env, |env, _cid| {
-            let hid = HuntyCore::create_hunt(env.clone(), creator, title, description, None, None)
-                .unwrap();
-            HuntyCore::list_clues(env.clone(), hid)
+            let seeded_hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Seeded Hunt"),
+                String::from_str(env, "Has a clue"),
+                None,
+                None,
+            )
+            .unwrap();
+            HuntyCore::add_clue(
+                env.clone(),
+                seeded_hunt_id,
+                String::from_str(env, "Q1"),
+                String::from_str(env, "a"),
+                1,
+                true,
+            )
+            .unwrap();
+
+            let empty_hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator,
+                String::from_str(env, "Empty Hunt"),
+                String::from_str(env, "No clues yet"),
+                None,
+                None,
+            )
+            .unwrap();
+
+            HuntyCore::list_clues(env.clone(), empty_hunt_id)
         });
 
-        assert_eq!(list.len(), 0);
+        let expected = Vec::new(&env);
+        assert_eq!(list, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Tighten the empty list_clues regression so it compares the returned Soroban vector against an explicit empty Vec.
- Keeps coverage focused on newly created hunts that have no clues.

## Verification
- Not run: cargo test -p hunty-core test_list_clues_empty (cargo/rustc are not installed in this environment).

Closes #148