### PR TITLE
Reward pool

### DIFF
--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1130,6 +1130,7 @@ mod test {
             hunt_id
         });
 
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), creator.clone(), hunt_id, 0).unwrap();
         });
@@ -2195,6 +2196,7 @@ mod test {
         });
 
         // Fund RewardManager pool for this hunt
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), funder.clone(), hunt_id, 0).unwrap();
         });
@@ -2383,6 +2385,7 @@ mod test {
         });
 
         // Fund RewardManager pool
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), funder.clone(), hunt_id, 0).unwrap();
         });

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -794,6 +794,41 @@ mod test {
     }
 
     #[test]
+    fn test_add_clue_after_activation_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Hunt");
+        let description = String::from_str(&env, "Desc");
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let err = with_core_contract(&env, |env, _cid| {
+            let hid = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title,
+                description,
+                None,
+                None,
+            )
+            .unwrap();
+
+            // Add a required clue to allow activation
+            HuntyCore::add_clue(env.clone(), hid, question.clone(), answer.clone(), 1, true).unwrap();
+
+            // Activate the hunt
+            HuntyCore::activate_hunt(env.clone(), hid, creator.clone()).unwrap();
+
+            // Attempt to add a clue after activation (should fail)
+            HuntyCore::add_clue(env.clone(), hid, question, answer, 1, false).unwrap_err()
+        });
+
+        assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+    }
+
+    #[test]
     fn test_add_clue_invalid_question_too_long() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -101,7 +101,6 @@ impl RewardManager {
         hunt_id: u64,
         min_distribution_amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
         creator.require_auth();
 
         if min_distribution_amount < 0 {
@@ -152,8 +151,6 @@ impl RewardManager {
         hunt_id: u64,
         amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
-        funder.require_auth();
 
         if amount <= 0 {
             return Err(RewardErrorCode::InvalidAmount);
@@ -165,6 +162,8 @@ impl RewardManager {
         if funder != pool_config.creator {
             return Err(RewardErrorCode::Unauthorized);
         }
+
+        pool_config.creator.require_auth();
 
         let xlm_token = Storage::get_xlm_token(&env)
             .ok_or(RewardErrorCode::NotInitialized)?;
@@ -207,6 +206,7 @@ impl RewardManager {
         if creator != pool_config.creator {
             return Err(RewardErrorCode::Unauthorized);
         }
+        pool_config.creator.require_auth();
 
         let balance = Storage::get_pool_balance(&env, hunt_id);
         if balance == 0 {
@@ -480,13 +480,11 @@ impl RewardManager {
         hunt_id: u64,
         recipient: Address,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
-        admin.require_auth();
-
         let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;
         if configured_admin != admin {
             return Err(RewardErrorCode::Unauthorized);
         }
+        configured_admin.require_auth();
 
         // Ensure the pool exists
         Storage::get_pool_config(&env, hunt_id).ok_or(RewardErrorCode::PoolNotFound)?;

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -267,6 +267,24 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
+    fn test_fund_reward_pool_requires_creator_auth() {
+        let env = Env::default();
+        // Do NOT mock auths here to test require_auth rejection
+        let (contract_id, token_address, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_contract(&env, &token_address);
+            crate::storage::Storage::set_pool_config(&env, 1, &crate::types::RewardPoolConfig {
+                creator: creator.clone(),
+                min_distribution_amount: 0,
+            });
+            let _ = RewardManager::fund_reward_pool(env.clone(), creator.clone(), 1, 1_000);
+        });
+    }
+
+    #[test]
     fn test_fund_reward_pool_additive() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
## What This Does
- Replaces parameter-based authorization checks with strict state-based `require_auth()` checks in `RewardManager` (`fund_reward_pool`, `refund_pool`, and `admin_withdraw_unclaimed`).
- Removes `#[cfg(not(test))]` skips to ensure authorization behaves identically in test and production environments.
- Adds `test_fund_reward_pool_requires_creator_auth` to explicitly verify that unauthorized funding attempts panic.
- Updates integration tests in `HuntyCore` to properly mock authorization for cross-contract setup.

## Why
Relying solely on `if funder != pool_config.creator` alongside an arbitrary `funder.require_auth()` leaves the contract vulnerable to logic bugs. Directly requiring authorization from the trusted state (`pool_config.creator`) is the recommended Soroban pattern, ensuring only the true creator can fund or refund a pool.

## Testing
- ✅ Added explicit rejection test `test_fund_reward_pool_requires_creator_auth`.
- ✅ Ran `make test` locally to ensure all unit and integration tests pass with the new auth flows.

## Related Issues
Closes #174
