### PR TITLE
docs: add step-by-step deployment guide for testnet and mainnet

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -277,21 +277,184 @@ pub fn create_hunt(env: Env, creator: Address) -> u64 {
 
 ## Deployment
 
-### Local Testing
+Hunty requires deploying three contracts in the correct order and wiring them together. The steps below cover both **testnet** and **mainnet**. Replace `--network testnet` with `--network mainnet` (and use a funded mainnet key) for production deployments.
+
+### Prerequisites
+
+1. **Stellar CLI** installed and on your PATH (`stellar --version`).
+2. A funded deployer keypair. On testnet, use the friendbot:
+   ```bash
+   stellar keys generate deployer --network testnet
+   stellar keys fund deployer --network testnet
+   ```
+3. All contracts built (`.wasm` files present):
+   ```bash
+   cargo build --target wasm32-unknown-unknown --release
+   ls target/wasm32-unknown-unknown/release/*.wasm
+   ```
+
+### Step 1 — Deploy NftReward
+
+NftReward has no initializer, so it can be deployed and used immediately.
 
 ```bash
-# Deploy to local network
-stellar contract deploy --wasm target/wasm32-unknown-unknown/release/hunty_core.wasm
+NFT_CONTRACT=$(stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/nft_reward.wasm \
+  --source deployer \
+  --network testnet)
+
+echo "NftReward: $NFT_CONTRACT"
 ```
 
-### Testnet Deployment
+### Step 2 — Deploy RewardManager
 
 ```bash
-# Deploy to testnet
-stellar contract deploy \
+REWARD_MANAGER=$(stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/reward_manager.wasm \
+  --source deployer \
+  --network testnet)
+
+echo "RewardManager: $REWARD_MANAGER"
+```
+
+#### 2a — Identify the XLM SAC address
+
+The XLM Stellar Asset Contract address differs by network.
+
+| Network  | XLM SAC address |
+|----------|----------------|
+| Testnet  | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
+| Mainnet  | `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA` |
+
+> Tip: verify with `stellar contract id asset --asset native --network testnet`.
+
+```bash
+# Testnet
+XLM_SAC="CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+```
+
+#### 2b — Initialize RewardManager
+
+`initialize` sets the admin keypair and the XLM SAC. It can only be called once.
+
+```bash
+DEPLOYER_ADDRESS=$(stellar keys address deployer)
+
+stellar contract invoke \
+  --id "$REWARD_MANAGER" \
+  --source deployer \
+  --network testnet \
+  -- initialize \
+  --admin "$DEPLOYER_ADDRESS" \
+  --xlm_token "$XLM_SAC"
+```
+
+#### 2c — Register NftReward with RewardManager
+
+```bash
+stellar contract invoke \
+  --id "$REWARD_MANAGER" \
+  --source deployer \
+  --network testnet \
+  -- set_nft_reward_contract \
+  --admin "$DEPLOYER_ADDRESS" \
+  --nft_contract "$NFT_CONTRACT"
+```
+
+### Step 3 — Deploy HuntyCore
+
+```bash
+HUNTY_CORE=$(stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/hunty_core.wasm \
-  --network testnet
+  --source deployer \
+  --network testnet)
+
+echo "HuntyCore: $HUNTY_CORE"
 ```
+
+#### 3a — Register RewardManager with HuntyCore
+
+`set_reward_manager` tells HuntyCore where to send reward-distribution calls.
+
+```bash
+stellar contract invoke \
+  --id "$HUNTY_CORE" \
+  --source deployer \
+  --network testnet \
+  -- set_reward_manager \
+  --reward_manager "$REWARD_MANAGER"
+```
+
+### Step 4 — Persist contract addresses
+
+Save the addresses so they can be reused across sessions and by your frontend.
+
+```bash
+cat << EOF > .env.testnet
+HUNTY_CORE=$HUNTY_CORE
+REWARD_MANAGER=$REWARD_MANAGER
+NFT_CONTRACT=$NFT_CONTRACT
+XLM_SAC=$XLM_SAC
+NETWORK=testnet
+EOF
+```
+
+### Step 5 — Fund a reward pool (hunt creator workflow)
+
+Before a hunt can pay out XLM rewards, its pool must be created and funded.
+Amounts are in **stroops** (1 XLM = 10 000 000 stroops).
+
+```bash
+HUNT_ID=1          # replace with your hunt ID after create_hunt
+AMOUNT=100000000   # 10 XLM in stroops
+
+# Create the pool
+stellar contract invoke \
+  --id "$REWARD_MANAGER" \
+  --source deployer \
+  --network testnet \
+  -- create_reward_pool \
+  --creator "$DEPLOYER_ADDRESS" \
+  --hunt_id "$HUNT_ID" \
+  --min_distribution_amount 0
+
+# Fund the pool (transfers XLM from the creator's account)
+stellar contract invoke \
+  --id "$REWARD_MANAGER" \
+  --source deployer \
+  --network testnet \
+  -- fund_reward_pool \
+  --funder "$DEPLOYER_ADDRESS" \
+  --hunt_id "$HUNT_ID" \
+  --amount "$AMOUNT"
+```
+
+### Step 6 — Verify the deployment
+
+```bash
+# Check reward pool status
+stellar contract invoke \
+  --id "$REWARD_MANAGER" \
+  --source deployer \
+  --network testnet \
+  -- get_reward_pool \
+  --hunt_id "$HUNT_ID"
+
+# Check NftReward supply (should be 0 before any completions)
+stellar contract invoke \
+  --id "$NFT_CONTRACT" \
+  --source deployer \
+  --network testnet \
+  -- total_supply
+```
+
+### Mainnet checklist
+
+- Use a hardware wallet or a dedicated deployment keypair; never use a hot key holding user funds.
+- Replace `--network testnet` with `--network mainnet` in every command above.
+- Use the mainnet XLM SAC: `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`.
+- Verify each contract ID with `stellar contract info --id <ID> --network mainnet` before calling `initialize`.
+- Keep `.env.mainnet` out of version control (add it to `.gitignore`).
 
 ## Resources
 


### PR DESCRIPTION
Add step-by-step deployment guide for testnet and mainnet
  
  Expands the ## Deployment section in DEVELOPMENT.md with a complete, ordered deployment
  walkthrough for all three Hunty contracts.
  
  What's included:
  
  - Ordered deployment steps: NftReward → RewardManager → HuntyCore
  - initialize call for RewardManager with admin and XLM SAC token address
  - Network-specific XLM SAC addresses for testnet and mainnet
  - set_nft_reward_contract to wire NftReward into RewardManager
  - set_reward_manager to wire RewardManager into HuntyCore
  - Reward pool creation and funding (with stroop denomination note)
  - Verification commands to confirm the deployment is live
  - Mainnet checklist covering key security and config differences
closes #161 