### PR TITLE
Feat/clue attempt limit manual pr

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -27,6 +27,7 @@ pub enum HuntErrorCode {
     RewardDistributionFailed = 20,
     NoRewardsConfigured = 21,
     NoRequiredClues = 22,
+    InvalidRarity = 23,
 }
 
 #[derive(Debug)]
@@ -51,6 +52,7 @@ pub enum HuntError {
     RewardDistributionFailed { hunt_id: u64 },
     NoRewardsConfigured { hunt_id: u64 },
     NoRequiredClues { hunt_id: u64 },
+    InvalidRarity { value: u32 },
 }
 
 impl fmt::Display for HuntError {
@@ -123,6 +125,9 @@ impl fmt::Display for HuntError {
             HuntError::NoRequiredClues { hunt_id } => {
                 write!(f, "Hunt {} has no required clues; at least one required clue must exist before activation", hunt_id)
             }
+            HuntError::InvalidRarity { value } => {
+                write!(f, "Invalid nft_rarity {}: must be 0-5", value)
+            }
         }
     }
 }
@@ -150,6 +155,7 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::RewardDistributionFailed { .. } => HuntErrorCode::RewardDistributionFailed,
             HuntError::NoRewardsConfigured { .. } => HuntErrorCode::NoRewardsConfigured,
             HuntError::NoRequiredClues { .. } => HuntErrorCode::NoRequiredClues,
+            HuntError::InvalidRarity { .. } => HuntErrorCode::InvalidRarity,
         }
     }
 }

--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -18,9 +18,11 @@ pub enum HuntErrorCode {
     InvalidTitle = 11,
     InvalidDescription = 12,
     InvalidAddress = 13,
-    TooManyClues = 14,
-    InvalidQuestion = 15,
-    RefundFailed = 16,
+    InvalidMaxAttempts = 14,
+    MaxAttemptsExceeded = 15,
+    TooManyClues = 16,
+    InvalidQuestion = 17,
+    RefundFailed = 18,
     NoCluesAdded = 17,
     HuntNotCompleted = 18,
     RewardAlreadyClaimed = 19,
@@ -45,6 +47,8 @@ pub enum HuntError {
     InvalidTitle { reason: String },
     InvalidDescription { reason: String },
     InvalidAddress,
+    InvalidMaxAttempts,
+    MaxAttemptsExceeded,
     TooManyClues { hunt_id: u64, limit: u32 },
     InvalidQuestion,
     HuntNotCompleted { hunt_id: u64 },
@@ -104,6 +108,12 @@ impl fmt::Display for HuntError {
             HuntError::InvalidAddress => {
                 write!(f, "Invalid address")
             }
+            HuntError::InvalidMaxAttempts => {
+                write!(f, "Invalid max attempts value")
+            }
+            HuntError::MaxAttemptsExceeded => {
+                write!(f, "Max answer attempts exceeded for this clue")
+            }
             HuntError::TooManyClues { hunt_id, limit } => {
                 write!(f, "Too many clues for hunt {} (limit {})", hunt_id, limit)
             }
@@ -148,6 +158,8 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::InvalidTitle { .. } => HuntErrorCode::InvalidTitle,
             HuntError::InvalidDescription { .. } => HuntErrorCode::InvalidDescription,
             HuntError::InvalidAddress => HuntErrorCode::InvalidAddress,
+            HuntError::InvalidMaxAttempts => HuntErrorCode::InvalidMaxAttempts,
+            HuntError::MaxAttemptsExceeded => HuntErrorCode::MaxAttemptsExceeded,
             HuntError::TooManyClues { .. } => HuntErrorCode::TooManyClues,
             HuntError::InvalidQuestion => HuntErrorCode::InvalidQuestion,
             HuntError::HuntNotCompleted { .. } => HuntErrorCode::HuntNotCompleted,

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -257,6 +257,11 @@ impl HuntyCore {
         b == 0x20 || b == 0x09 || b == 0x0a || b == 0x0d
     }
 
+    #[inline]
+    fn validate_rarity(v: u32) -> bool {
+        v <= 5
+    }
+
     pub fn activate_hunt(env: Env, hunt_id: u64, caller: Address) -> Result<(), HuntErrorCode> {
         let mut hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
 
@@ -492,6 +497,10 @@ impl HuntyCore {
 
         let reward_amount = hunt.reward_config.reward_per_winner();
         let nft_awarded = hunt.reward_config.nft_enabled;
+
+        if !Self::validate_rarity(hunt.reward_config.nft_rarity) {
+            return Err(HuntErrorCode::InvalidRarity);
+        }
 
         // Call RewardManager if configured and there are rewards to distribute
         if let Some(reward_manager_addr) = Storage::get_reward_manager(env) {

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -15,6 +15,7 @@ use soroban_sdk::{
 const MAX_QUESTION_LENGTH: u32 = 2000;
 const MAX_ANSWER_LENGTH: u32 = 256;
 const MAX_CLUES_PER_HUNT: u32 = 100;
+const DEFAULT_MAX_ATTEMPTS_PER_CLUE: u32 = 5;
 /// Maximum number of leaderboard entries returned (gas and UX limit).
 const MAX_LEADERBOARD_SIZE: u32 = 20;
 /// Maximum number of player records scanned when building leaderboard responses.
@@ -100,6 +101,7 @@ impl HuntyCore {
             reward_config,
             total_clues: 0, // Empty clue list initially
             required_clues: 0,
+            max_attempts_per_clue: DEFAULT_MAX_ATTEMPTS_PER_CLUE,
         };
 
         // Store the hunt
@@ -115,6 +117,30 @@ impl HuntyCore {
             .publish((Symbol::new(&env, "HuntCreated"), hunt_id), event);
 
         Ok(hunt_id)
+    }
+
+    /// Sets the maximum number of incorrect answer attempts per clue for a hunt.
+    pub fn set_max_attempts(
+        env: Env,
+        hunt_id: u64,
+        caller: Address,
+        max_attempts_per_clue: u32,
+    ) -> Result<(), HuntErrorCode> {
+        if max_attempts_per_clue == 0 {
+            return Err(HuntErrorCode::InvalidMaxAttempts);
+        }
+
+        let mut hunt = Storage::get_hunt_or_error(&env, hunt_id).map_err(HuntErrorCode::from)?;
+        if hunt.creator != caller {
+            return Err(HuntErrorCode::Unauthorized);
+        }
+        if hunt.status != HuntStatus::Draft {
+            return Err(HuntErrorCode::InvalidHuntStatus);
+        }
+
+        hunt.max_attempts_per_clue = max_attempts_per_clue;
+        Storage::save_hunt(&env, &hunt);
+        Ok(())
     }
 
     /// Adds a clue to a hunt. Only the hunt creator can add clues.
@@ -699,11 +725,17 @@ impl HuntyCore {
             return Err(HuntErrorCode::ClueAlreadyCompleted);
         }
 
+        let attempts = progress.failed_attempts_for_clue(clue_id);
+        if attempts >= hunt.max_attempts_per_clue {
+            return Err(HuntErrorCode::MaxAttemptsExceeded);
+        }
+
         let submitted_hash =
             Self::normalize_and_hash_answer(&env, &answer).map_err(HuntErrorCode::from)?;
 
         if submitted_hash != clue.answer_hash {
-            // Answer is incorrect - emit analytics event and return error
+            progress.record_failed_attempt(clue_id);
+            Storage::save_player_progress(&env, &progress);
             let incorrect_event = AnswerIncorrectEvent {
                 hunt_id,
                 player: player.clone(),

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1592,6 +1592,55 @@ mod test {
     }
 
     #[test]
+    fn test_submit_answer_enforces_max_attempts_per_clue() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        let contract_id = env.register_contract(None, HuntyCore);
+        let creator = Address::generate(&env);
+        let player = Address::generate(&env);
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+        let wrong = String::from_str(&env, "bad");
+
+        let hunt_id = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Hunt"),
+                String::from_str(env, "Desc"),
+                None,
+                None,
+            )
+            .unwrap()
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer.clone(), 1, true)
+                .unwrap();
+            HuntyCore::set_max_attempts(env.clone(), hunt_id, creator.clone(), 2)
+                .unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), wrong.clone())
+                .unwrap_err();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), wrong.clone())
+                .unwrap_err();
+            let err = HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), wrong)
+                .unwrap_err();
+            assert_eq!(err, HuntErrorCode::MaxAttemptsExceeded);
+        });
+    }
+
+    #[test]
     fn test_get_completed_clues_empty_when_not_registered() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Map, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -37,6 +37,7 @@ pub struct Hunt {
     pub reward_config: RewardConfig,
     pub total_clues: u32,
     pub required_clues: u32,
+    pub max_attempts_per_clue: u32,
 }
 
 /// Stored clue with SHA256 answer hash. The hash is never exposed via get_clue/list_clues or events.
@@ -103,6 +104,7 @@ impl Default for Location {
 #[derive(Clone, Debug)]
 pub struct StoredPlayerProgress {
     pub completed_clues: Vec<u32>,
+    pub clue_attempts: Map<u32, u32>,
     pub total_score: u32,
     pub started_at: u64,
     pub completed_at: u64,
@@ -117,6 +119,7 @@ pub struct PlayerProgress {
     pub player: Address,
     pub hunt_id: u64,
     pub completed_clues: Vec<u32>,
+    pub clue_attempts: Map<u32, u32>,
     pub total_score: u32,
     pub started_at: u64,
     pub completed_at: u64,
@@ -130,6 +133,7 @@ impl PlayerProgress {
             player,
             hunt_id,
             completed_clues: Vec::new(env),
+            clue_attempts: Map::new(env),
             total_score: 0,
             started_at: current_time,
             completed_at: 0,
@@ -142,6 +146,7 @@ impl PlayerProgress {
     pub fn to_stored(&self) -> StoredPlayerProgress {
         StoredPlayerProgress {
             completed_clues: self.completed_clues.clone(),
+            clue_attempts: self.clue_attempts.clone(),
             total_score: self.total_score,
             started_at: self.started_at,
             completed_at: self.completed_at,
@@ -156,6 +161,7 @@ impl PlayerProgress {
             player,
             hunt_id,
             completed_clues: stored.completed_clues,
+            clue_attempts: stored.clue_attempts,
             total_score: stored.total_score,
             started_at: stored.started_at,
             completed_at: stored.completed_at,
@@ -171,6 +177,15 @@ impl PlayerProgress {
             }
         }
         false
+    }
+
+    pub fn failed_attempts_for_clue(&self, clue_id: u32) -> u32 {
+        self.clue_attempts.get(&clue_id).unwrap_or(0)
+    }
+
+    pub fn record_failed_attempt(&mut self, clue_id: u32) {
+        let current = self.failed_attempts_for_clue(clue_id);
+        self.clue_attempts.set(clue_id, current + 1);
     }
 
     pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32) {

--- a/contracts/nft-reward/src/errors.rs
+++ b/contracts/nft-reward/src/errors.rs
@@ -9,4 +9,5 @@ pub enum NftErrorCode {
     NotOwner = 3,
     InvalidRecipient = 4,
     SoulboundNft = 5,
+    InvalidRarity = 6,
 }

--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -102,6 +102,9 @@ impl NftReward {
         player_address: Address,
         metadata: NftMetadata,
     ) -> u64 {
+        if metadata.rarity > 5 {
+            panic!("InvalidRarity");
+        }
         let minted_at = env.ledger().timestamp();
 
         let nft_id = Storage::next_nft_id(&env);
@@ -174,6 +177,10 @@ impl NftReward {
             .get(Symbol::new(&env, "rarity"))
             .and_then(|v| u32::try_from_val(&env, &v).ok())
             .unwrap_or(0u32);
+
+        if rarity > 5 {
+            panic!("InvalidRarity");
+        }
 
         let tier = metadata
             .get(Symbol::new(&env, "tier"))

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -351,6 +351,9 @@ impl RewardManager {
 
         // Route to NFT handler if configured
         if reward_config.has_nft() {
+            if reward_config.nft_rarity > 5 {
+                return Err(RewardErrorCode::InvalidConfig);
+            }
             let nft_contract = reward_config
                 .nft_contract
                 .as_ref()


### PR DESCRIPTION
Introduce [max_attempts_per_clue] to hunts


Track failed clue attempts in player progress
Enforce attempt limits in [submit_answer]


Add [set_max_attempts(...)] for hunt creators
Add regression coverage for max-attempt enforcement


closes #83