### PR TITLE
fix: replace unbounded Vec in add_nft_to_owner with paginated index (Issue #86)

### DIFF
--- a/contracts/nft-reward/src/storage.rs
+++ b/contracts/nft-reward/src/storage.rs
@@ -7,14 +7,25 @@ pub struct Storage;
 impl Storage {
     const NFT_KEY: soroban_sdk::Symbol = symbol_short!("NFT");
     const NFT_COUNTER_KEY: soroban_sdk::Symbol = symbol_short!("CNTR");
-    const OWNER_NFTS_KEY: soroban_sdk::Symbol = symbol_short!("ONFT");
+    const OWNER_NFT_COUNT_KEY: soroban_sdk::Symbol = symbol_short!("ONFC");
 
     fn nft_key(nft_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::NFT_KEY, nft_id)
     }
 
-    fn owner_nfts_key(owner: &Address) -> (soroban_sdk::Symbol, Address) {
-        (Self::OWNER_NFTS_KEY, owner.clone())
+    /// Key for a single owner-nft entry: (ONFT, owner, index)
+    fn owner_nft_entry_key(owner: &Address, index: u32) -> (soroban_sdk::Symbol, Address, u32) {
+        (symbol_short!("ONFT"), owner.clone(), index)
+    }
+
+    /// Key for the count of NFTs owned: (ONFC, owner)
+    fn owner_nft_count_key(owner: &Address) -> (soroban_sdk::Symbol, Address) {
+        (Self::OWNER_NFT_COUNT_KEY, owner.clone())
+    }
+
+    /// Key for existence check: (ONFX, owner, nft_id)
+    fn owner_nft_exist_key(owner: &Address, nft_id: u64) -> (soroban_sdk::Symbol, Address, u64) {
+        (symbol_short!("ONFX"), owner.clone(), nft_id)
     }
 
     /// Saves an NFT to persistent storage.
@@ -45,38 +56,73 @@ impl Storage {
             .unwrap_or(0)
     }
 
-    /// Adds an NFT ID to the owner's list.
+    /// Adds an NFT ID to the owner's index.
+    /// Each entry is stored at its own key so no single entry grows unboundedly.
     pub fn add_nft_to_owner(env: &Env, owner: &Address, nft_id: u64) {
-        let key = Self::owner_nfts_key(owner);
-        let mut nft_ids = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or_else(|| Vec::new(env));
-        nft_ids.push_back(nft_id);
-        env.storage().persistent().set(&key, &nft_ids);
-    }
+        let count_key = Self::owner_nft_count_key(owner);
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
 
-    /// Removes an NFT ID from the owner's list.
-    pub fn remove_nft_from_owner(env: &Env, owner: &Address, nft_id: u64) {
-        let key = Self::owner_nfts_key(owner);
-        let mut nft_ids = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or_else(|| Vec::new(env));
-        if let Some(idx) = nft_ids.first_index_of(nft_id) {
-            nft_ids.remove(idx);
+        let exist_key = Self::owner_nft_exist_key(owner, nft_id);
+        if env.storage().persistent().has(&exist_key) {
+            return;
         }
-        env.storage().persistent().set(&key, &nft_ids);
-    }
 
-    /// Gets all NFT IDs owned by an address.
-    pub fn get_owner_nfts(env: &Env, owner: &Address) -> Vec<u64> {
-        let key = Self::owner_nfts_key(owner);
         env.storage()
             .persistent()
-            .get(&key)
-            .unwrap_or_else(|| Vec::new(env))
+            .set(&Self::owner_nft_entry_key(owner, count), &nft_id);
+        env.storage().persistent().set(&count_key, &(count + 1));
+        env.storage().persistent().set(&exist_key, &());
+    }
+
+    /// Removes an NFT ID from the owner's index.
+    pub fn remove_nft_from_owner(env: &Env, owner: &Address, nft_id: u64) {
+        let count_key = Self::owner_nft_count_key(owner);
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+
+        let exist_key = Self::owner_nft_exist_key(owner, nft_id);
+        if !env.storage().persistent().has(&exist_key) {
+            return;
+        }
+
+        // Find the entry index and swap-remove with the last entry
+        let mut found = false;
+        for i in 0..count {
+            let entry_key = Self::owner_nft_entry_key(owner, i);
+            if let Some(stored_id) = env.storage().persistent().get::<_, u64>(&entry_key) {
+                if stored_id == nft_id {
+                    let last_idx = count - 1;
+                    if i != last_idx {
+                        let last_key = Self::owner_nft_entry_key(owner, last_idx);
+                        if let Some(last_id) = env.storage().persistent().get::<_, u64>(&last_key) {
+                            env.storage().persistent().set(&entry_key, &last_id);
+                        }
+                        env.storage().persistent().remove(&last_key);
+                    } else {
+                        env.storage().persistent().remove(&entry_key);
+                    }
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if found {
+            env.storage().persistent().set(&count_key, &(count - 1));
+        }
+        env.storage().persistent().remove(&exist_key);
+    }
+
+    /// Gets all NFT IDs owned by an address by reading individual entries.
+    pub fn get_owner_nfts(env: &Env, owner: &Address) -> Vec<u64> {
+        let count_key = Self::owner_nft_count_key(owner);
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        let mut ids = Vec::new(env);
+        for i in 0..count {
+            let entry_key = Self::owner_nft_entry_key(owner, i);
+            if let Some(id) = env.storage().persistent().get(&entry_key) {
+                ids.push_back(id);
+            }
+        }
+        ids
     }
 }


### PR DESCRIPTION
## Summary
Replace the single unbounded Vec<u64> per owner with a paginated index, preventing storage bloat and excessive deserialization costs as player NFT collections grow.

## Related Issue
Closes #86

## Problem
dd_nft_to_owner stores all NFT IDs for an owner in a single Vec<u64> at one storage key. For prolific players, this Vec grows without bound, increasing deserialization (storage read) cost with every mint and eventually hitting Soroban storage limits.

## Solution
Refactored the owner-NFT index to use the same paginated pattern already established in hunty-core for clue lists and player addresses:

- **ONFC (owner NFT count)** � (Symbol, Address) -> u32 � stores how many NFTs an owner has
- **ONFT (owner NFT entry)** � (Symbol, Address, u32) -> u64 � individual NFT ID at index
- **ONFX (owner NFT existence)** � (Symbol, Address, u64) -> () � O(1) duplicate check

This ensures each storage key holds a fixed-size value, eliminating unbounded growth.

## Changes
- contracts/nft-reward/src/storage.rs � Rewrote dd_nft_to_owner, emove_nft_from_owner, and get_owner_nfts to use the paginated index pattern
- All 18 existing tests continue to pass (2 pre-existing test failures related to soulbound transfer are unrelated)
