### PR TITLE
fix: propagate NFT mint failures from reward manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 Hunty is a decentralized scavenger hunt game built on Stellar/Soroban. Create thrilling scavenger hunts with multiple clues and challenges, engage players in immersive treasure hunts, and reward them with XLM tokens or exclusive NFTs.
 
 
-
-
 ## What is Hunty?
 
 Imagine a treasure hunt where every clue is verified on the blockchain, every answer is secure, and every completion is rewarded with real value. That's Hunty.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Hunty is a decentralized scavenger hunt game built on Stellar/Soroban. Create thrilling scavenger hunts with multiple clues and challenges, engage players in immersive treasure hunts, and reward them with XLM tokens or exclusive NFTs.
 
+
+
+
 ## What is Hunty?
 
 Imagine a treasure hunt where every clue is verified on the blockchain, every answer is secure, and every completion is rewarded with real value. That's Hunty.

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -369,7 +369,7 @@ impl RewardManager {
                 reward_config.nft_hunt_title.clone(),
                 reward_config.nft_rarity,
                 reward_config.nft_tier,
-            ));
+            )?);
         }
 
         // All operations succeeded — update state atomically

--- a/contracts/reward-manager/src/nft_handler.rs
+++ b/contracts/reward-manager/src/nft_handler.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{Address, Env, IntoVal, Map, Symbol};
 
+use crate::errors::RewardErrorCode;
+
 pub struct NftHandler;
 
 impl NftHandler {
@@ -30,7 +32,7 @@ impl NftHandler {
         hunt_title: soroban_sdk::String,
         rarity: u32,
         tier: u32,
-    ) -> u64 {
+    ) -> Result<u64, RewardErrorCode> {
         let mut metadata: Map<soroban_sdk::Symbol, soroban_sdk::Val> = Map::new(env);
         metadata.set(soroban_sdk::Symbol::new(env, "title"), title.into_val(env));
         metadata.set(
@@ -53,10 +55,12 @@ impl NftHandler {
         args.push_back(player.clone().into_val(env));
         args.push_back(metadata.into_val(env));
 
-        env.invoke_contract(
+        env.try_invoke_contract(
             nft_contract,
             &Symbol::new(env, "mint_reward_nft_from_map"),
             args,
         )
+        .map_err(|_| RewardErrorCode::NftMintFailed)?
+        .map_err(|_| RewardErrorCode::NftMintFailed)
     }
 }

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -652,6 +652,33 @@ mod test {
     }
 
     #[test]
+    fn test_distribute_rewards_propagates_nft_mint_failure() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, _) = setup(&env);
+        let player = Address::generate(&env);
+        let missing_nft_contract = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_contract(&env, &token_address);
+
+            let config = RewardConfig {
+                xlm_amount: None,
+                nft_contract: Some(missing_nft_contract),
+                nft_title: soroban_sdk::String::from_str(&env, "NFT"),
+                nft_description: soroban_sdk::String::from_str(&env, "desc"),
+                nft_image_uri: soroban_sdk::String::from_str(&env, "uri"),
+                nft_hunt_title: soroban_sdk::String::from_str(&env, "hunt"),
+                nft_rarity: 0,
+                nft_tier: 0,
+            };
+
+            let result = RewardManager::distribute_rewards(env.clone(), 1, player.clone(), config);
+            assert_eq!(result, Err(RewardErrorCode::NftMintFailed));
+        });
+    }
+
+    #[test]
     fn test_distribute_rewards_not_initialized() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
Closes #130

Summary:
- switch `NftHandler::distribute_nft` from `invoke_contract` to `try_invoke_contract`
- map cross-contract mint failures to `NftMintFailed` instead of panicking
- add a regression test for NFT mint failure propagation