### PR TITLE
Reward manager

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -4,8 +4,8 @@ use crate::storage::Storage;
 use crate::types::{
     AnswerIncorrectEvent, Clue, ClueAddedEvent, ClueCompletedEvent, ClueInfo, Hunt,
     HuntActivatedEvent, HuntCancelledEvent, HuntCompletedEvent, HuntCreatedEvent,
-    HuntDeactivatedEvent, HuntStatistics, HuntStatus, LeaderboardEntry, PlayerProgress,
-    PlayerRegisteredEvent, RewardClaimedEvent, RewardConfig,
+    HuntDeactivatedEvent, HuntStatistics, HuntStatus, HuntRewardConfig, LeaderboardEntry, PlayerProgress,
+    PlayerRegisteredEvent, RewardClaimedEvent,
 };
 use reward_manager::RewardErrorCode;
 use soroban_sdk::{
@@ -78,7 +78,8 @@ impl HuntyCore {
         let hunt_id = Storage::next_hunt_id(&env);
 
         // Initialize reward config with zero pool
-        let reward_config = RewardConfig::new(
+        let reward_config = HuntRewardConfig::new(
+            &env,
             0,     // xlm_pool: zero initially
             false, // nft_enabled: false initially
             None,  // nft_contract: None initially
@@ -500,49 +501,20 @@ impl HuntyCore {
             } else {
                 None
             };
-            // description is intentionally excluded from NFT metadata: a creator could
-            // accidentally embed an answer or salt in the hunt description, which would
-            // then be permanently exposed on-chain via the cross-contract call.
-            // Only the title (already fully public) is forwarded.
-            let (nft_contract, nft_title, nft_desc, nft_uri, nft_hunt_title) = if nft_awarded {
-                hunt.reward_config
-                    .nft_contract
-                    .clone()
-                    .map(|nft_contract| {
-                        (
-                            Some(nft_contract),
-                            hunt.title.clone(),
-                            String::from_str(env, ""),
-                            String::from_str(env, ""),
-                            hunt.title.clone(),
-                        )
-                    })
-                    .unwrap_or((
-                        None,
-                        String::from_str(env, ""),
-                        String::from_str(env, ""),
-                        String::from_str(env, ""),
-                        String::from_str(env, ""),
-                    ))
+
+            let mut rm_reward_config = hunt.reward_config.distribution_config.clone();
+            rm_reward_config.xlm_amount = xlm_amount;
+
+            if nft_awarded {
+                // description is intentionally excluded from NFT metadata: a creator could
+                // accidentally embed an answer or salt in the hunt description, which would
+                // then be permanently exposed on-chain via the cross-contract call.
+                // Only the title (already fully public) is forwarded.
+                rm_reward_config.nft_title = hunt.title.clone();
+                rm_reward_config.nft_hunt_title = hunt.title.clone();
             } else {
-                (
-                    None,
-                    String::from_str(env, ""),
-                    String::from_str(env, ""),
-                    String::from_str(env, ""),
-                    String::from_str(env, ""),
-                )
-            };
-            let rm_reward_config = reward_manager::RewardConfig {
-                xlm_amount,
-                nft_contract,
-                nft_title,
-                nft_description: nft_desc,
-                nft_image_uri: nft_uri,
-                nft_hunt_title,
-                nft_rarity: hunt.reward_config.nft_rarity,
-                nft_tier: hunt.reward_config.nft_tier,
-            };
+                rm_reward_config.nft_contract = None;
+            }
 
             // Only call RewardManager when there is at least one reward type
             if rm_reward_config.is_valid() {

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -407,7 +407,7 @@ mod test {
         // Verify default reward config values
         assert_eq!(reward_config.xlm_pool, 0);
         assert_eq!(reward_config.nft_enabled, false);
-        assert_eq!(reward_config.nft_contract, None);
+        assert_eq!(reward_config.distribution_config.nft_contract, None);
         assert_eq!(reward_config.max_winners, 0);
         assert_eq!(reward_config.claimed_count, 0);
     }
@@ -2097,7 +2097,8 @@ mod test {
 
             // Update reward config on the hunt
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config = crate::types::RewardConfig::new(
+            hunt.reward_config = crate::types::HuntRewardConfig::new(
+                env,
                 xlm_pool,
                 false,
                 None,
@@ -2180,7 +2181,8 @@ mod test {
 
             // Configure rewards on the hunt: 3 winners sharing 9_000 XLM
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config = crate::types::RewardConfig::new(
+            hunt.reward_config = crate::types::HuntRewardConfig::new(
+                env,
                 9_000,
                 true,
                 Some(nft_contract_id.clone()),
@@ -2369,7 +2371,8 @@ mod test {
 
             // Configure rewards: xlm_pool = 6_000, max_winners = 3
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config = crate::types::RewardConfig::new(
+            hunt.reward_config = crate::types::HuntRewardConfig::new(
+                env,
                 6_000,
                 true,
                 Some(nft_contract_id.clone()),
@@ -2517,7 +2520,7 @@ mod test {
             .unwrap();
 
             let mut hunt = Storage::get_hunt(env, hid).unwrap();
-            hunt.reward_config = crate::types::RewardConfig::new(1000, false, None, 10, 0, 0);
+            hunt.reward_config = crate::types::HuntRewardConfig::new(env, 1000, false, None, 10, 0, 0);
             Storage::save_hunt(env, &hunt);
 
             HuntyCore::activate_hunt(env.clone(), hid, creator.clone()).unwrap();
@@ -2604,8 +2607,7 @@ mod test {
             .unwrap();
 
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config =
-                crate::types::RewardConfig::new(1000, false, None, 5, 0, 0);
+            hunt.reward_config = crate::types::HuntRewardConfig::new(env, 1000, false, None, 5, 0, 0);
             Storage::save_hunt(env, &hunt);
 
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1130,6 +1130,7 @@ mod test {
             hunt_id
         });
 
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), creator.clone(), hunt_id, 0).unwrap();
         });
@@ -2195,6 +2196,7 @@ mod test {
         });
 
         // Fund RewardManager pool for this hunt
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), funder.clone(), hunt_id, 0).unwrap();
         });
@@ -2383,6 +2385,7 @@ mod test {
         });
 
         // Fund RewardManager pool
+        env.mock_all_auths();
         env.as_contract(&reward_manager_id, || {
             RewardManager::create_reward_pool(env.clone(), funder.clone(), hunt_id, 0).unwrap();
         });

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -794,6 +794,41 @@ mod test {
     }
 
     #[test]
+    fn test_add_clue_after_activation_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Hunt");
+        let description = String::from_str(&env, "Desc");
+        let question = String::from_str(&env, "Q");
+        let answer = String::from_str(&env, "a");
+
+        let err = with_core_contract(&env, |env, _cid| {
+            let hid = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title,
+                description,
+                None,
+                None,
+            )
+            .unwrap();
+
+            // Add a required clue to allow activation
+            HuntyCore::add_clue(env.clone(), hid, question.clone(), answer.clone(), 1, true).unwrap();
+
+            // Activate the hunt
+            HuntyCore::activate_hunt(env.clone(), hid, creator.clone()).unwrap();
+
+            // Attempt to add a clue after activation (should fail)
+            HuntyCore::add_clue(env.clone(), hid, question, answer, 1, false).unwrap_err()
+        });
+
+        assert_eq!(err, HuntErrorCode::InvalidHuntStatus);
+    }
+
+    #[test]
     fn test_add_clue_invalid_question_too_long() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -11,16 +11,12 @@ pub enum HuntStatus {
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RewardConfig {
+pub struct HuntRewardConfig {
     pub xlm_pool: i128,
-    pub nft_enabled: bool,
-    pub nft_contract: Option<Address>,
     pub max_winners: u32,
     pub claimed_count: u32,
-    /// NFT rarity: 0 = default, 1-5 = common to legendary.
-    pub nft_rarity: u32,
-    /// NFT tier: 0 = none, custom tier value.
-    pub nft_tier: u32,
+    pub nft_enabled: bool,
+    pub distribution_config: reward_manager::RewardConfig,
 }
 
 #[contracttype]
@@ -34,7 +30,7 @@ pub struct Hunt {
     pub created_at: u64,
     pub activated_at: u64,
     pub end_time: u64,
-    pub reward_config: RewardConfig,
+    pub reward_config: HuntRewardConfig,
     pub total_clues: u32,
     pub required_clues: u32,
 }
@@ -191,8 +187,9 @@ impl Hunt {
     }
 }
 
-impl RewardConfig {
+impl HuntRewardConfig {
     pub fn new(
+        env: &Env,
         xlm_pool: i128,
         nft_enabled: bool,
         nft_contract: Option<Address>,
@@ -202,12 +199,19 @@ impl RewardConfig {
     ) -> Self {
         Self {
             xlm_pool,
-            nft_enabled,
-            nft_contract,
             max_winners,
             claimed_count: 0,
-            nft_rarity,
-            nft_tier,
+            nft_enabled,
+            distribution_config: reward_manager::RewardConfig {
+                xlm_amount: None,
+                nft_contract,
+                nft_title: String::from_str(env, ""),
+                nft_description: String::from_str(env, ""),
+                nft_image_uri: String::from_str(env, ""),
+                nft_hunt_title: String::from_str(env, ""),
+                nft_rarity,
+                nft_tier,
+            },
         }
     }
 

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -101,7 +101,6 @@ impl RewardManager {
         hunt_id: u64,
         min_distribution_amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
         creator.require_auth();
 
         if min_distribution_amount < 0 {
@@ -152,8 +151,6 @@ impl RewardManager {
         hunt_id: u64,
         amount: i128,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
-        funder.require_auth();
 
         if amount <= 0 {
             return Err(RewardErrorCode::InvalidAmount);
@@ -165,6 +162,8 @@ impl RewardManager {
         if funder != pool_config.creator {
             return Err(RewardErrorCode::Unauthorized);
         }
+
+        pool_config.creator.require_auth();
 
         let xlm_token = Storage::get_xlm_token(&env)
             .ok_or(RewardErrorCode::NotInitialized)?;
@@ -207,6 +206,7 @@ impl RewardManager {
         if creator != pool_config.creator {
             return Err(RewardErrorCode::Unauthorized);
         }
+        pool_config.creator.require_auth();
 
         let balance = Storage::get_pool_balance(&env, hunt_id);
         if balance == 0 {
@@ -480,13 +480,11 @@ impl RewardManager {
         hunt_id: u64,
         recipient: Address,
     ) -> Result<(), RewardErrorCode> {
-        #[cfg(not(test))]
-        admin.require_auth();
-
         let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;
         if configured_admin != admin {
             return Err(RewardErrorCode::Unauthorized);
         }
+        configured_admin.require_auth();
 
         // Ensure the pool exists
         Storage::get_pool_config(&env, hunt_id).ok_or(RewardErrorCode::PoolNotFound)?;

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -267,6 +267,24 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
+    fn test_fund_reward_pool_requires_creator_auth() {
+        let env = Env::default();
+        // Do NOT mock auths here to test require_auth rejection
+        let (contract_id, token_address, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_contract(&env, &token_address);
+            crate::storage::Storage::set_pool_config(&env, 1, &crate::types::RewardPoolConfig {
+                creator: creator.clone(),
+                min_distribution_amount: 0,
+            });
+            let _ = RewardManager::fund_reward_pool(env.clone(), creator.clone(), 1, 1_000);
+        });
+    }
+
+    #[test]
     fn test_fund_reward_pool_additive() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();

--- a/contracts/reward-manager/src/types.rs
+++ b/contracts/reward-manager/src/types.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contracttype, Address, String};
 /// Configuration for distributing rewards. Uses only primitive/Option types for reliable contracttype.
 /// At least one of xlm_amount or nft_contract must be set for a valid distribution.
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RewardConfig {
     /// XLM amount to distribute. None if no XLM rewards.
     pub xlm_amount: Option<i128>,


### PR DESCRIPTION
## What This Does
- Derives `PartialEq` and `Eq` on `reward_manager::RewardConfig` so it can be utilized in state comparisons.
- Renames `RewardConfig` in `HuntyCore` to `HuntRewardConfig` to prevent naming collisions.
- Replaces overlapping NFT fields in `HuntRewardConfig` with an embedded `reward_manager::RewardConfig` instance.
- Updates the reward distribution logic in `HuntyCore` to directly pass the nested config rather than manually mapping identical fields.

## Why
Previously, both crates defined separate config structs with overlapping fields (`nft_contract`, `nft_rarity`, `nft_tier`, etc.). Any future updates to the NFT metadata schema or distribution logic would require manual mirroring in both crates, leading to potential configuration drift and bugs. By using the `RewardManager`'s struct as the single source of truth, both contracts are guaranteed to stay perfectly in sync.

## Testing
- ✅ Updated unit and integration tests in `HuntyCore` to conform to the new `HuntRewardConfig` structure.
- ✅ Ran `make test` locally to ensure no logic regressions exist.

## Related Issues
Closes #126
