### PR TITLE
perf: #90 replace O(n²) leaderboard selection with linear top-k scan

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -816,85 +816,83 @@ impl HuntyCore {
         let queried_at = env.ledger().timestamp();
         let players = Storage::get_hunt_players(&env, hunt_id);
         let scan_limit = core::cmp::min(players.len(), MAX_LEADERBOARD_SCAN_SIZE);
-        let mut entries = Vec::new(&env);
-        for i in 0..scan_limit {
-            let p = players.get(i).unwrap();
-            entries.push_back((
-                p.player.clone(),
-                p.total_score,
-                p.completed_at,
-                p.is_completed,
-            ));
-        }
-        let mut selected = Vec::new(&env);
-        let mut result = Vec::new(&env);
-        for rank in 1..=effective_limit {
-            if let Some(best_idx) = Self::leaderboard_best_index(&entries, &selected) {
-                selected.push_back(best_idx);
-                let (player, score, completed_at, is_completed) = entries.get(best_idx).unwrap();
-                result.push_back(LeaderboardEntry {
-                    rank,
-                    player,
-                    score,
-                    completed_at,
-                    is_completed,
-                    queried_at,
-                });
-            } else {
-                break;
+
+        // Single linear top-k pass. We keep at most `effective_limit` entries in
+        // `top` at all times, ordered best-first. For each player we find the
+        // insertion point against the current top-k and splice them in, dropping
+        // anything past the limit. This is O(scan_limit * effective_limit) with
+        // effective_limit <= 20, replacing the previous O(effective_limit *
+        // scan_limit) repeated-selection scan and its inner `selected` lookup.
+        // Allocation is bounded to the k-sized result vector.
+        let mut top: Vec<(Address, u32, u64, bool)> = Vec::new(&env);
+        if effective_limit > 0 {
+            for i in 0..scan_limit {
+                let p = players.get(i).unwrap();
+                let candidate = (p.player.clone(), p.total_score, p.completed_at, p.is_completed);
+
+                // Find the first position whose occupant is worse than the
+                // candidate; that is where the candidate belongs.
+                let len = top.len();
+                let mut pos = len;
+                let mut j = 0;
+                while j < len {
+                    let existing = top.get(j).unwrap();
+                    if Self::leaderboard_is_better(&candidate, &existing) {
+                        pos = j;
+                        break;
+                    }
+                    j += 1;
+                }
+
+                // If the board is already full and the candidate is no better
+                // than the last entry, skip it entirely.
+                if pos >= effective_limit {
+                    continue;
+                }
+
+                top.insert(pos, candidate);
+                // Trim anything beyond the limit (at most one element).
+                if top.len() > effective_limit {
+                    top.remove(top.len() - 1);
+                }
             }
+        }
+
+        let mut result = Vec::new(&env);
+        let mut rank = 1u32;
+        for entry in top.iter() {
+            let (player, score, completed_at, is_completed) = entry;
+            result.push_back(LeaderboardEntry {
+                rank,
+                player,
+                score,
+                completed_at,
+                is_completed,
+                queried_at,
+            });
+            rank += 1;
         }
         Ok(result)
     }
 
-    /// Picks the index of the best entry not in `selected`. Order: score desc, then completed_at asc (0 = last).
-    fn leaderboard_best_index(
-        entries: &Vec<(Address, u32, u64, bool)>,
-        selected: &Vec<u32>,
-    ) -> Option<u32> {
-        let n = entries.len();
-        let mut best_idx: Option<u32> = None;
-        for i in 0..n {
-            let i_u32 = i as u32;
-            let mut taken = false;
-            for j in 0..selected.len() {
-                if selected.get(j).unwrap() == i_u32 {
-                    taken = true;
-                    break;
-                }
-            }
-            if taken {
-                continue;
-            }
-            let (_, score, completed_at, _) = entries.get(i).unwrap();
-            let better = match best_idx {
-                None => true,
-                Some(bi) => {
-                    let (_, b_score, b_completed_at, _) = entries.get(bi).unwrap();
-                    if score > b_score {
-                        true
-                    } else if score == b_score {
-                        let a_val = if completed_at == 0 {
-                            u64::MAX
-                        } else {
-                            completed_at
-                        };
-                        let b_val = if b_completed_at == 0 {
-                            u64::MAX
-                        } else {
-                            b_completed_at
-                        };
-                        a_val < b_val
-                    } else {
-                        false
-                    }
-                }
-            };
-            if better {
-                best_idx = Some(i_u32);
-            }
+    /// Ordering predicate for leaderboard entries: returns true if `a` should
+    /// rank strictly ahead of `b`. Order: score descending, then `completed_at`
+    /// ascending where 0 (not yet completed) is treated as last.
+    fn leaderboard_is_better(
+        a: &(Address, u32, u64, bool),
+        b: &(Address, u32, u64, bool),
+    ) -> bool {
+        let (_, a_score, a_completed_at, _) = a;
+        let (_, b_score, b_completed_at, _) = b;
+        if a_score > b_score {
+            true
+        } else if a_score == b_score {
+            let a_val = if *a_completed_at == 0 { u64::MAX } else { *a_completed_at };
+            let b_val = if *b_completed_at == 0 { u64::MAX } else { *b_completed_at };
+            a_val < b_val
+        } else {
+            false
         }
-        best_idx
     }
 
     /// Returns aggregate statistics for a hunt (read-only): total players, completion rate, average score.

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -1350,7 +1350,7 @@ mod test {
                 HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
 
-            Ok(())
+            Ok::<(), soroban_sdk::Error>(())
         });
     }
 


### PR DESCRIPTION
## Summary
 
`get_hunt_leaderboard` previously built its ranking with a repeated-selection scan: for each of up to `effective_limit` ranks, it called `leaderboard_best_index`, which scanned all candidate entries and the growing `selected` list to find the next-best unpicked entry. That nests an O(n) scan inside an O(limit) loop — the quadratic cost described in #90, which becomes meaningful at `MAX_LEADERBOARD_SCAN_SIZE = 200`.
 
This PR replaces that with a single linear top-k pass.
 
## Approach
 
- One pass over up to `MAX_LEADERBOARD_SCAN_SIZE` entries, maintaining a sorted top-k buffer (`top`) capped at `effective_limit` (≤ 20). Each candidate is compared against the current buffer, inserted at its rank position, and anything past the cap is dropped. This is O(`scan_limit` × `effective_limit`) with no inner `selected` lookup, and allocation is bounded to the k-sized result.
- The ordering rule is extracted into a small `leaderboard_is_better` predicate: **score descending, then `completed_at` ascending where `0` (not yet completed) is treated as last.** This preserves the exact ordering semantics of the previous `leaderboard_best_index` comparator.
- `leaderboard_best_index` is removed (its only caller was `get_hunt_leaderboard`).
- `get_hunt_leaderboard_window` is left unchanged.
## Changes
 
- `contracts/hunty-core/src/lib.rs` — rewrote the selection logic in `get_hunt_leaderboard`; replaced `leaderboard_best_index` with `leaderboard_is_better`.
- `contracts/hunty-core/src/test.rs` — one-line type annotation on a pre-existing `Ok(())` (E0282) that was blocking the test binary from compiling. Unrelated to the leaderboard logic, but required to run the test suite.
## Testing
 
- `cargo build -p hunty-core` compiles clean (only pre-existing dead-code warnings).
- `cargo test -p hunty-core leaderboard` → **4 passed, 0 failed:**
  - `test_get_hunt_leaderboard_sorted_by_score_then_completion_time` (the ordering guarantee — confirms the rewrite preserves behavior)
  - `test_get_hunt_leaderboard_empty`
  - `test_get_hunt_leaderboard_limit_capped`
  - `test_get_hunt_leaderboard_hunt_not_found`
## Rebase / merge status
 
I rebased this branch onto current `main` and resolved the `lib.rs` conflict (kept `get_hunt_leaderboard_window`, replaced `leaderboard_best_index` with the linear approach above). The resolution is clean — no conflict markers remain.
 
However, **current `main` does not compile**, independent of this change:
 
```
error[E0283]/[E0284]: type annotations needed
  --> contracts/reward-manager/src/nft_handler.rs:58:13
     env.try_invoke_contract(   // cannot infer type parameter `E`
```
 
Because `hunty-core` depends on `reward-manager`, this pre-existing breakage blocks any build on top of current `main`. I've therefore held the rebased push rather than submit a branch that fails CI for reasons unrelated to this PR. The branch as it stands builds and passes the leaderboard tests against the pre-breakage base (results above).
 
I'm happy to complete the rebase and push as soon as `main` builds again. The blocker looks like a missing type annotation on the `try_invoke_contract` call (the compiler suggests `try_invoke_contract::<u64, RewardErrorCode>(...)` or similar), but that lives in a different crate and is outside the scope of this issue, so I've left it for a maintainer.
 
Closes #90