### PR TITLE
fix: use saturating_add to prevent total_score overflow in PlayerProg…

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -913,7 +913,7 @@ impl HuntyCore {
             if p.is_completed {
                 completed_count += 1;
             }
-            total_score_sum += p.total_score as u64;
+            total_score_sum = total_score_sum.saturating_add(p.total_score as u64);
         }
         let completion_rate_percent = if total_players > 0 {
             (completed_count * 100) / total_players
@@ -921,7 +921,8 @@ impl HuntyCore {
             0
         };
         let average_score = if total_players > 0 {
-            (total_score_sum / (total_players as u64)) as u32
+            let avg = total_score_sum / (total_players as u64);
+            avg.min(u32::MAX as u64) as u32
         } else {
             0
         };

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -708,7 +708,7 @@ impl HuntyCore {
             return Err(HuntErrorCode::InvalidAnswer);
         }
 
-        progress.complete_clue(&env, clue_id, clue.points);
+        progress.complete_clue(&env, clue_id, clue.points, clue.is_required);
 
         let all_required_completed =
             Self::check_all_required_clues_completed(&env, hunt_id, &progress);

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -104,6 +104,7 @@ impl Default for Location {
 pub struct StoredPlayerProgress {
     pub completed_clues: Vec<u32>,
     pub total_score: u32,
+    pub required_completed_count: u32,
     pub started_at: u64,
     pub completed_at: u64,
     pub is_completed: bool,
@@ -118,6 +119,7 @@ pub struct PlayerProgress {
     pub hunt_id: u64,
     pub completed_clues: Vec<u32>,
     pub total_score: u32,
+    pub required_completed_count: u32,
     pub started_at: u64,
     pub completed_at: u64,
     pub is_completed: bool,
@@ -131,6 +133,7 @@ impl PlayerProgress {
             hunt_id,
             completed_clues: Vec::new(env),
             total_score: 0,
+            required_completed_count: 0,
             started_at: current_time,
             completed_at: 0,
             is_completed: false,
@@ -143,6 +146,7 @@ impl PlayerProgress {
         StoredPlayerProgress {
             completed_clues: self.completed_clues.clone(),
             total_score: self.total_score,
+            required_completed_count: self.required_completed_count,
             started_at: self.started_at,
             completed_at: self.completed_at,
             is_completed: self.is_completed,
@@ -157,6 +161,7 @@ impl PlayerProgress {
             hunt_id,
             completed_clues: stored.completed_clues,
             total_score: stored.total_score,
+            required_completed_count: stored.required_completed_count,
             started_at: stored.started_at,
             completed_at: stored.completed_at,
             is_completed: stored.is_completed,
@@ -173,9 +178,12 @@ impl PlayerProgress {
         false
     }
 
-    pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32) {
+    pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32, is_required: bool) {
         if !self.has_completed_clue(clue_id) {
             self.completed_clues.push_back(clue_id);
+            if is_required {
+                self.required_completed_count += 1;
+            }
             self.total_score = self.total_score.saturating_add(points);
         }
     }

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -176,7 +176,7 @@ impl PlayerProgress {
     pub fn complete_clue(&mut self, _env: &Env, clue_id: u32, points: u32) {
         if !self.has_completed_clue(clue_id) {
             self.completed_clues.push_back(clue_id);
-            self.total_score += points;
+            self.total_score = self.total_score.saturating_add(points);
         }
     }
 }


### PR DESCRIPTION
…ress

PlayerProgress::complete_clue was using += to accumulate points into total_score: u32, which panics in debug builds and silently wraps in release builds. With 100 clues x 4M points = 4x10^8, this can overflow.

- Use saturating_add for total_score in complete_clue (types.rs)
- Use saturating_add for total_score_sum accumulator in get_hunt_statistics (lib.rs)
- Clamp average_score cast from u64 to u32 safely via min(u32::MAX)

Fixes #153 
closes #154