### PR TITLE
end_time not validated to be in the future at hunt creation

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -27,6 +27,7 @@ pub enum HuntErrorCode {
     RewardDistributionFailed = 20,
     NoRewardsConfigured = 21,
     NoRequiredClues = 22,
+    InvalidEndTime = 23,
 }
 
 #[derive(Debug)]
@@ -51,6 +52,7 @@ pub enum HuntError {
     RewardDistributionFailed { hunt_id: u64 },
     NoRewardsConfigured { hunt_id: u64 },
     NoRequiredClues { hunt_id: u64 },
+    InvalidEndTime,
 }
 
 impl fmt::Display for HuntError {
@@ -123,6 +125,9 @@ impl fmt::Display for HuntError {
             HuntError::NoRequiredClues { hunt_id } => {
                 write!(f, "Hunt {} has no required clues; at least one required clue must exist before activation", hunt_id)
             }
+            HuntError::InvalidEndTime => {
+                write!(f, "Invalid end time: must be in the future")
+            }
         }
     }
 }
@@ -150,6 +155,7 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::RewardDistributionFailed { .. } => HuntErrorCode::RewardDistributionFailed,
             HuntError::NoRewardsConfigured { .. } => HuntErrorCode::NoRewardsConfigured,
             HuntError::NoRequiredClues { .. } => HuntErrorCode::NoRequiredClues,
+            HuntError::InvalidEndTime => HuntErrorCode::InvalidEndTime,
         }
     }
 }

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -74,6 +74,13 @@ impl HuntyCore {
         // Get current timestamp
         let current_time = env.ledger().timestamp();
 
+        // Validate end_time
+        if let Some(et) = end_time {
+            if et > 0 && et <= current_time {
+                return Err(HuntErrorCode::InvalidEndTime);
+            }
+        }
+
         // Generate unique hunt ID
         let hunt_id = Storage::next_hunt_id(&env);
 

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -148,7 +148,7 @@ mod test {
         let creator = Address::generate(&env);
         let title = String::from_str(&env, "Timed Hunt");
         let description = String::from_str(&env, "A hunt with an end time");
-        let end_time = 1000000u64;
+        let end_time = 1_700_086_400u64; // 1 day in the future
 
         let hunt = with_core_contract(&env, |env, _cid| {
             let hunt_id = HuntyCore::create_hunt(
@@ -164,6 +164,42 @@ mod test {
         });
         assert_eq!(hunt.end_time, end_time);
     }
+
+    #[test]
+    fn test_create_hunt_invalid_end_time() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Expired Hunt");
+        let description = String::from_str(&env, "A hunt with an expired end time");
+        let end_time = 1_700_000_000; // equal to current time (invalid)
+
+        let result = with_core_contract(&env, |env, _cid| {
+            HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title.clone(),
+                description.clone(),
+                None,
+                Some(end_time),
+            )
+        });
+        assert_eq!(result, Err(HuntErrorCode::InvalidEndTime));
+
+        let end_time_past = 1_699_999_999; // in the past (invalid)
+        let result_past = with_core_contract(&env, |env, _cid| {
+            HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title.clone(),
+                description.clone(),
+                None,
+                Some(end_time_past),
+            )
+        });
+        assert_eq!(result_past, Err(HuntErrorCode::InvalidEndTime));
+    }
+
 
     #[test]
     fn test_create_hunt_empty_title() {

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,4 @@
+#93 end_time not validated to be in the future at hunt creation
+Repo Avatar
+Samuel1-ona/Hunty-contract
+Validation: create_hunt stores any end_time value without checking end_time > current_time. A creator can accidentally set an already-expired end time, making the hunt immediately inaccessible after activation.


### PR DESCRIPTION
I  have implemented the validation check to ensure that the end_time of a hunt is set in the future at the time of creation.

Changes Made
1. Errors Definition
Modified 
errors.rs
 to add:
HuntErrorCode::InvalidEndTime (value 23)
HuntError::InvalidEndTime
2. Validation Implementation
Modified 
lib.rs (HuntyCore)
 inside the create_hunt function to validate:
rust

if let Some(et) = end_time {
    if et > 0 && et <= current_time {
        return Err(HuntErrorCode::InvalidEndTime);
    }
}
3. Test Cases
Modified 
test.rs
:
Updated test_create_hunt_with_end_time to use a future timestamp 1_700_086_400u64 (relative to the ledger timestamp 1_700_000_000).
Added a new unit test test_create_hunt_invalid_end_time to verify that both past and present end_time values return the InvalidEndTime error code.
Verification
Cargo compilation and local test runner execution were attempted, but execution of the compiled build scripts (syn, thiserror, zmij, etc.) was blocked by the system's machine-wide Windows Defender Application Control (WDAC) / AppLocker security policy (os error 4551).
The source code changes have been fully implemented, verified for syntactical correctness, and successfully committed and pushed to the remote branch fix/validate-end-time.

- Closes #93 