### PR TITLE
fix(reward-manager): validate hunt_id exists in HuntyCore before creating pool (#142)

### DIFF
--- a/contracts/reward-manager/src/errors.rs
+++ b/contracts/reward-manager/src/errors.rs
@@ -21,4 +21,6 @@ pub enum RewardErrorCode {
     BelowMinimumAmount = 11,
     /// Contract initialization can only happen once.
     AlreadyInitialized = 12,
+    /// hunt_id does not exist in HuntyCore (validated via cross-contract call).
+    HuntNotFound = 13,
 }

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), no_std)]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, Symbol, Val, Vec};
 
 pub use crate::errors::RewardErrorCode;
 pub use crate::types::{
@@ -82,6 +82,23 @@ impl RewardManager {
         Ok(())
     }
 
+    /// Sets the optional HuntyCore contract address used to validate hunt_id existence
+    /// in `create_reward_pool`. When set, pool creation will be rejected for unknown
+    /// hunt IDs. If not set, hunt_id is assumed caller-trusted.
+    pub fn set_hunty_core(
+        env: Env,
+        admin: Address,
+        hunty_core: Address,
+    ) -> Result<(), RewardErrorCode> {
+        admin.require_auth();
+        let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;
+        if configured_admin != admin {
+            return Err(RewardErrorCode::Unauthorized);
+        }
+        Storage::set_hunty_core(&env, &hunty_core);
+        Ok(())
+    }
+
     /// Creates a reward pool for a specific hunt.
     ///
     /// Must be called before `fund_reward_pool`. Only the creator is authorized
@@ -95,6 +112,7 @@ impl RewardManager {
     /// # Errors
     /// * `PoolAlreadyExists` - A pool already exists for this hunt_id
     /// * `InvalidAmount` - min_distribution_amount is negative
+    /// * `HuntNotFound` - hunt_id does not exist in HuntyCore (only when `set_hunty_core` has been called)
     pub fn create_reward_pool(
         env: Env,
         creator: Address,
@@ -109,6 +127,23 @@ impl RewardManager {
 
         if Storage::get_pool_config(&env, hunt_id).is_some() {
             return Err(RewardErrorCode::PoolAlreadyExists);
+        }
+
+        // Validate hunt_id exists in HuntyCore when the core contract is configured.
+        // If not configured, hunt_id is caller-trusted (no cross-contract call is made).
+        if let Some(hunty_core) = Storage::get_hunty_core(&env) {
+            let mut args: Vec<Val> = Vec::new(&env);
+            args.push_back(hunt_id.into_val(&env));
+            // get_hunt_info returns Result<Hunt, HuntErrorCode>.
+            // We use Val as the success type to avoid importing Hunt from hunty-core.
+            // Any non-Ok(Ok(_)) result means the hunt doesn't exist or the call failed.
+            let hunt_exists = matches!(
+                env.try_invoke_contract::<Val, Val>(&hunty_core, &Symbol::new(&env, "get_hunt_info"), args),
+                Ok(Ok(_))
+            );
+            if !hunt_exists {
+                return Err(RewardErrorCode::HuntNotFound);
+            }
         }
 
         let config = RewardPoolConfig {

--- a/contracts/reward-manager/src/storage.rs
+++ b/contracts/reward-manager/src/storage.rs
@@ -14,6 +14,7 @@ impl Storage {
     const POOL_CFG_KEY: soroban_sdk::Symbol = symbol_short!("PCFG");
     const POOL_DEP_KEY: soroban_sdk::Symbol = symbol_short!("PDEP");
     const POOL_DST_KEY: soroban_sdk::Symbol = symbol_short!("PDST");
+    const HUNTY_CORE_KEY: soroban_sdk::Symbol = symbol_short!("HCORE");
 
     // ========== XLM Token Address ==========
 
@@ -31,6 +32,16 @@ impl Storage {
 
     pub fn get_xlm_token(env: &Env) -> Option<Address> {
         env.storage().persistent().get(&Self::XLM_TOKEN_KEY)
+    }
+
+    // ========== HuntyCore Contract Address (optional) ==========
+
+    pub fn set_hunty_core(env: &Env, address: &Address) {
+        env.storage().persistent().set(&Self::HUNTY_CORE_KEY, address);
+    }
+
+    pub fn get_hunty_core(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&Self::HUNTY_CORE_KEY)
     }
 
     // ========== Default NFT Contract Address ==========

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -1088,4 +1088,78 @@ mod test {
             assert_eq!(result, Err(RewardErrorCode::NotInitialized));
         });
     }
+    // ========== set_hunty_core / hunt_id validation ==========
+
+    #[test]
+    fn test_create_reward_pool_without_hunty_core_is_caller_trusted() {
+        // Without set_hunty_core, any hunt_id is accepted (caller-trusted mode).
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            // hunt_id 9999 is arbitrary — no HuntyCore is configured, so it passes.
+            let result = RewardManager::create_reward_pool(env.clone(), creator.clone(), 9999, 0);
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_create_reward_pool_rejects_unknown_hunt_id_when_hunty_core_set() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, _) = setup(&env);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        // Register a dummy contract as "hunty_core". Any call to get_hunt_info on it
+        // will fail (no matching function), which simulates a missing hunt.
+        let fake_hunty_core = env.register(RewardManager, ());
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            RewardManager::set_hunty_core(env.clone(), admin.clone(), fake_hunty_core.clone())
+                .unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            // hunt_id 42 doesn't exist in the fake core — expect HuntNotFound.
+            let result = RewardManager::create_reward_pool(env.clone(), creator.clone(), 42, 0);
+            assert_eq!(result, Err(RewardErrorCode::HuntNotFound));
+        });
+    }
+
+    #[test]
+    fn test_set_hunty_core_admin_only() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, token_address, _) = setup(&env);
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let fake_core = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::initialize(env.clone(), admin.clone(), token_address.clone()).unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            // Non-admin should be rejected.
+            let result =
+                RewardManager::set_hunty_core(env.clone(), attacker.clone(), fake_core.clone());
+            assert_eq!(result, Err(RewardErrorCode::Unauthorized));
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            // Admin succeeds.
+            RewardManager::set_hunty_core(env.clone(), admin.clone(), fake_core.clone()).unwrap();
+            assert_eq!(
+                crate::storage::Storage::get_hunty_core(&env),
+                Some(fake_core)
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary
`create_reward_pool` previously accepted any `hunt_id` without verifying it existed in HuntyCore, allowing orphan pools to be created that waste storage and confuse accounting.

## Changes

### Validation via cross-contract call (optional)
- Added `set_hunty_core(admin, hunty_core)` admin function to configure the HuntyCore contract address
- When configured, `create_reward_pool` calls `get_hunt_info` via `try_invoke_contract` to verify the hunt exists before creating the pool
- Returns new `HuntNotFound` error (code 13) if the hunt does not exist in HuntyCore

### Caller-trusted fallback (backward compatible)
- If `set_hunty_core` has not been called, `hunt_id` remains caller-trusted — no change in behavior for existing deployments

## Files Changed
- `contracts/reward-manager/src/errors.rs` — Added `HuntNotFound = 13`
- `contracts/reward-manager/src/storage.rs` — Added `set_hunty_core` / `get_hunty_core` storage methods
- `contracts/reward-manager/src/lib.rs` — Added `set_hunty_core` function + validation logic in `create_reward_pool`
- `contracts/reward-manager/src/test.rs` — Added 3 tests

## Tests Added
- `test_create_reward_pool_without_hunty_core_is_caller_trusted` — any `hunt_id` accepted when HuntyCore is not configured
- `test_create_reward_pool_rejects_unknown_hunt_id_when_hunty_core_set` — `HuntNotFound` returned for unknown hunt IDs when HuntyCore is configured
- `test_set_hunty_core_admin_only` — only admin can call `set_hunty_core`

closes #142
