### PR TITLE
feat: add global total_xlm_distributed accumulator for protocol analytics

### DIFF
--- a/contracts/nft-reward/src/test.rs
+++ b/contracts/nft-reward/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 use crate::{NftMetadata, NftReward, NftRewardClient};
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, String,
+    Address, Env, String, Map, Symbol, Val, IntoVal,
 };
 
 fn setup_env() -> Env {
@@ -239,6 +239,49 @@ fn test_get_nft_metadata_returns_complete_info() {
     assert_eq!(meta.image_uri, String::from_str(&env, "ipfs://trophy"));
     assert_eq!(meta.rarity, 4);
     assert_eq!(meta.tier, 1);
+}
+
+#[test]
+fn test_mint_from_map_then_query_metadata() {
+    let env = setup_env();
+    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+
+    let player = Address::generate(&env);
+
+    let mut metadata_map: Map<Symbol, Val> = Map::new(&env);
+    metadata_map.set(
+        Symbol::new(&env, "title"),
+        String::from_str(&env, "Map Mint Trophy").into_val(&env),
+    );
+    metadata_map.set(
+        Symbol::new(&env, "description"),
+        String::from_str(&env, "Minted via map").into_val(&env),
+    );
+    metadata_map.set(
+        Symbol::new(&env, "image_uri"),
+        String::from_str(&env, "ipfs://mapmint").into_val(&env),
+    );
+    metadata_map.set(
+        Symbol::new(&env, "hunt_title"),
+        String::from_str(&env, "Map Hunt").into_val(&env),
+    );
+    metadata_map.set(Symbol::new(&env, "rarity"), 2u32.into_val(&env));
+    metadata_map.set(Symbol::new(&env, "tier"), 7u32.into_val(&env));
+
+    let nft_id = client.mint_reward_nft_from_map(&7, &player, &metadata_map);
+    let meta = client.get_nft_metadata(&nft_id).unwrap();
+
+    assert_eq!(meta.nft_id, nft_id);
+    assert_eq!(meta.hunt_id, 7);
+    assert_eq!(meta.hunt_title, String::from_str(&env, "Map Hunt"));
+    assert_eq!(meta.completion_timestamp, 1000);
+    assert_eq!(meta.completion_player, player);
+    assert_eq!(meta.current_owner, player);
+    assert_eq!(meta.title, String::from_str(&env, "Map Mint Trophy"));
+    assert_eq!(meta.description, String::from_str(&env, "Minted via map"));
+    assert_eq!(meta.image_uri, String::from_str(&env, "ipfs://mapmint"));
+    assert_eq!(meta.rarity, 2);
+    assert_eq!(meta.tier, 7);
 }
 
 #[test]

--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -30,6 +30,7 @@ pub struct RewardPoolFundedEvent {
     pub funder: Address,
     pub amount: i128,
     pub new_balance: i128,
+    pub total_deposited: i128,
 }
 
 /// Event emitted when rewards are successfully distributed.
@@ -189,6 +190,7 @@ impl RewardManager {
                 funder,
                 amount,
                 new_balance,
+                total_deposited,
             },
         );
 
@@ -347,6 +349,9 @@ impl RewardManager {
             // Track cumulative distributed amount
             let total_distributed = Storage::get_pool_total_distributed(&env, hunt_id) + amount;
             Storage::set_pool_total_distributed(&env, hunt_id, total_distributed);
+            // Update protocol-level global total distributed
+            let global_total = Storage::get_total_xlm_distributed(&env) + amount;
+            Storage::set_total_xlm_distributed(&env, global_total);
         }
 
         // Route to NFT handler if configured
@@ -394,6 +399,13 @@ impl RewardManager {
         env.events()
             .publish((symbol_short!("RWD_DIST"), hunt_id), event);
 
+        Ok(())
+
+
+    /// Returns the total XLM distributed across all hunts (protocol-level metric).
+    pub fn get_total_xlm_distributed(env: Env) -> i128 {
+        Storage::get_total_xlm_distributed(&env)
+    }
         Ok(())
     }
 

--- a/contracts/reward-manager/src/storage.rs
+++ b/contracts/reward-manager/src/storage.rs
@@ -14,6 +14,7 @@ impl Storage {
     const POOL_CFG_KEY: soroban_sdk::Symbol = symbol_short!("PCFG");
     const POOL_DEP_KEY: soroban_sdk::Symbol = symbol_short!("PDEP");
     const POOL_DST_KEY: soroban_sdk::Symbol = symbol_short!("PDST");
+    const TOTAL_XLM_DST_KEY: soroban_sdk::Symbol = symbol_short!("TXLD");
 
     // ========== XLM Token Address ==========
 
@@ -125,6 +126,16 @@ impl Storage {
     pub fn get_pool_total_distributed(env: &Env, hunt_id: u64) -> i128 {
         let key = Self::pool_dst_key(hunt_id);
         env.storage().persistent().get(&key).unwrap_or(0)
+    }
+
+    // ========== Global Total XLM Distributed (across all hunts) ==========
+
+    pub fn set_total_xlm_distributed(env: &Env, amount: i128) {
+        env.storage().persistent().set(&Self::TOTAL_XLM_DST_KEY, &amount);
+    }
+
+    pub fn get_total_xlm_distributed(env: &Env) -> i128 {
+        env.storage().persistent().get(&Self::TOTAL_XLM_DST_KEY).unwrap_or(0)
     }
 
     // ========== Key Helpers ==========


### PR DESCRIPTION
## Summary
Closes #197

Adds a global `total_xlm_distributed` counter that accumulates XLM distributed across all hunts, enabling protocol-level analytics.

## What was missing
`get_pool_total_distributed` only tracks distribution per hunt. There was no way to query the total XLM distributed across the entire protocol.

## What this PR does
- Adds a global `total_xlm_distributed` storage key
- Updates `distribute_rewards` to increment the global accumulator on every reward distribution
- Adds a `get_total_xlm_distributed` query function for protocol-level analytics

## Type of change
- [x] New feature (non-breaking addition)