### PR TITLE
feat(reward-manager): add update_pool_config to allow creator to update min_distribution_amount (#141)

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -129,6 +129,46 @@ impl RewardManager {
         Ok(())
     }
 
+    /// Updates the `min_distribution_amount` for an existing reward pool.
+    ///
+    /// Only the pool creator is authorized to call this. Useful when a creator
+    /// has underfunded the pool and needs to lower the minimum so distributions
+    /// can proceed.
+    ///
+    /// # Arguments
+    /// * `creator` - The pool creator (must match the stored creator)
+    /// * `hunt_id` - The hunt whose pool config to update
+    /// * `min_distribution_amount` - New minimum XLM per distribution (0 = no minimum)
+    ///
+    /// # Errors
+    /// * `PoolNotFound` - No pool exists for this hunt_id
+    /// * `Unauthorized` - Caller is not the pool creator
+    /// * `InvalidAmount` - min_distribution_amount is negative
+    pub fn update_pool_config(
+        env: Env,
+        creator: Address,
+        hunt_id: u64,
+        min_distribution_amount: i128,
+    ) -> Result<(), RewardErrorCode> {
+        creator.require_auth();
+
+        let mut config = Storage::get_pool_config(&env, hunt_id)
+            .ok_or(RewardErrorCode::PoolNotFound)?;
+
+        if creator != config.creator {
+            return Err(RewardErrorCode::Unauthorized);
+        }
+
+        if min_distribution_amount < 0 {
+            return Err(RewardErrorCode::InvalidAmount);
+        }
+
+        config.min_distribution_amount = min_distribution_amount;
+        Storage::set_pool_config(&env, hunt_id, &config);
+
+        Ok(())
+    }
+
     /// Funds the reward pool for a specific hunt.
     ///
     /// The pool must have been created via `create_reward_pool` first.

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -171,6 +171,103 @@ mod test {
         });
     }
 
+    // ========== update_pool_config ==========
+
+    #[test]
+    fn test_update_pool_config_success() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 500).unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            // Lower the minimum
+            RewardManager::update_pool_config(env.clone(), creator.clone(), 1, 100).unwrap();
+
+            let status = RewardManager::get_reward_pool(env.clone(), 1).unwrap();
+            assert_eq!(status.min_distribution_amount, 100);
+            // Creator field must not change
+            assert_eq!(status.creator, creator);
+        });
+    }
+
+    #[test]
+    fn test_update_pool_config_to_zero() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 1_000).unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            // Remove the minimum entirely
+            RewardManager::update_pool_config(env.clone(), creator.clone(), 1, 0).unwrap();
+
+            let status = RewardManager::get_reward_pool(env.clone(), 1).unwrap();
+            assert_eq!(status.min_distribution_amount, 0);
+        });
+    }
+
+    #[test]
+    fn test_update_pool_config_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 500).unwrap();
+
+            let result =
+                RewardManager::update_pool_config(env.clone(), attacker.clone(), 1, 100);
+            assert_eq!(result, Err(RewardErrorCode::Unauthorized));
+
+            // Original value unchanged
+            let status = RewardManager::get_reward_pool(env.clone(), 1).unwrap();
+            assert_eq!(status.min_distribution_amount, 500);
+        });
+    }
+
+    #[test]
+    fn test_update_pool_config_pool_not_found() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let result =
+                RewardManager::update_pool_config(env.clone(), creator.clone(), 99, 100);
+            assert_eq!(result, Err(RewardErrorCode::PoolNotFound));
+        });
+    }
+
+    #[test]
+    fn test_update_pool_config_negative_amount() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, _, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            RewardManager::create_reward_pool(env.clone(), creator.clone(), 1, 500).unwrap();
+        });
+        env.mock_all_auths_allowing_non_root_auth();
+        env.as_contract(&contract_id, || {
+            let result =
+                RewardManager::update_pool_config(env.clone(), creator.clone(), 1, -1);
+            assert_eq!(result, Err(RewardErrorCode::InvalidAmount));
+        });
+    }
+
     // ========== fund_reward_pool ==========
 
     #[test]


### PR DESCRIPTION
## Summary
`min_distribution_amount` was fixed at pool creation time with no update path. If a creator underfunds the pool and needs to lower the minimum so distributions can proceed, there was no way to do so.

## Changes

### New function: `update_pool_config`

```rust
pub fn update_pool_config(
    env: Env,
    creator: Address,
    hunt_id: u64,
    min_distribution_amount: i128,
) -> Result<(), RewardErrorCode>


closes  #141