### PR TITLE
163 Storage TTL strategy undocumented — data expiry risks not communi…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,7 @@
 ### Prerequisites Installation
 
 **macOS:**
+
 ```bash
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -14,6 +15,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 **Linux:**
+
 ```bash
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -23,7 +25,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 **Windows:**
-```powershell
+
+```bash
 # Install Rust
 # Download from https://rustup.rs/
 
@@ -42,78 +45,296 @@ stellar --version
 ### Project Setup
 
 1. **Clone and navigate:**
-   ```bash
-   git clone https://github.com/Samuel1-ona/Hunty-contract.git
-   cd Hunty-contract
-   ```
+
+```bash
+git clone https://github.com/Samuel1-ona/Hunty-contract.git
+cd Hunty-contract
+```
 
 2. **Build all contracts:**
-   ```bash
-   # Build hunty-core
-   cd contracts/hunty-core
-   make build
-   
-   # Build reward-manager
-   cd ../reward-manager
-   make build
-   
-   # Build nft-reward
-   cd ../nft-reward
-   make build
-   ```
+
+```bash
+# Build hunty-core
+cd contracts/hunty-core
+make build
+
+# Build reward-manager
+cd ../reward-manager
+make build
+
+# Build nft-reward
+cd ../nft-reward
+make build
+```
 
 3. **Run tests:**
-   ```bash
-   # From each contract directory
-   make test
-   ```
+
+```bash
+# From each contract directory
+make test
+```
+
+---
+
+## Storage Architecture & TTL Management
+
+> **This section is required reading before modifying any contract storage or deploying to mainnet.**
+> Soroban's rent / TTL model differs fundamentally from EVM storage — data that is not periodically
+> "bumped" will be **archived (evicted) automatically** by the network after its time-to-live expires.
+> Evicted data is not deleted forever, but restoring it requires a separate `restore_footprint`
+> transaction and a fee; if operators are unaware of this, live hunts can become silently unplayable.
+
+### Soroban Storage Types — Primer
+
+Soroban exposes three storage buckets, each with different TTL defaults and use cases:
+
+| Type           | Accessed via                 | Default TTL (Futurenet / Testnet)                                                                    | Typical use                                                                |
+| -------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Instance**   | `env.storage().instance()`   | Tied to the contract instance entry; extended whenever the contract is invoked                       | Admin config, contract-level counters, flags that must always be available |
+| **Persistent** | `env.storage().persistent()` | Network-configured minimum (≈ 120 days on mainnet at time of writing); **not** auto-bumped on invoke | Per-hunt data, per-player progress, clue answers, reward pools             |
+| **Temporary**  | `env.storage().temporary()`  | Short-lived (minutes to hours); **auto-deleted** when expired, not archivable                        | Nonces, short-lived session flags — **never used for game state**          |
+
+> The exact ledger counts for minimum/maximum TTL are governance-controlled and may change. Always
+> check the [Stellar Network Settings](https://stellar.expert/explorer/mainnet/network-settings) for
+> current values before deploying.
+
+### Key → Storage Type Mapping
+
+The table below documents every storage key used across the three Hunty contracts and which storage
+type it lives in. Keep this table up-to-date whenever a new key is introduced.
+
+#### HuntyCore (`contracts/hunty-core/src/storage.rs`)
+
+| Storage Key                                | Type           | Description                                                          | Eviction risk                                                                         |
+| ------------------------------------------ | -------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `DataKey::Hunt(hunt_id)`                   | **Persistent** | Full `Hunt` struct (title, description, status, creator, clue count) | High — must be bumped while hunt is active                                            |
+| `DataKey::Clue(hunt_id, clue_id)`          | **Persistent** | `Clue` struct including SHA-256 answer hash                          | High — unreadable clues silently block answer verification                            |
+| `DataKey::PlayerProgress(hunt_id, player)` | **Persistent** | `PlayerProgress` struct (completed clues, score, timestamps)         | High — lost progress means players cannot complete hunts                              |
+| `DataKey::HuntPlayers(hunt_id)`            | **Persistent** | `Vec<Address>` of registered players (used by leaderboard)           | Medium — leaderboard queries degrade gracefully, but re-registration would be blocked |
+| `DataKey::HuntCount`                       | **Instance**   | Monotonic counter used to generate hunt IDs                          | Low — bumped automatically on every invocation                                        |
+| `DataKey::RewardManager`                   | **Instance**   | Address of the registered `RewardManager` contract                   | Low — bumped automatically on every invocation                                        |
+
+#### RewardManager (`contracts/reward-manager/src/lib.rs`)
+
+| Storage Key                    | Type           | Description                                                         | Eviction risk                                                                        |
+| ------------------------------ | -------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `DataKey::RewardPool(hunt_id)` | **Persistent** | `RewardPool` struct (balance, min distribution amount, funded flag) | **Critical** — eviction causes reward distribution to fail with a storage-miss panic |
+| `DataKey::NftRewardContract`   | **Instance**   | Address of the `NftReward` contract                                 | Low — bumped automatically on every invocation                                       |
+| `DataKey::Admin`               | **Instance**   | Admin `Address` authorised to configure the contract                | Low — bumped automatically on every invocation                                       |
+| `DataKey::XlmToken`            | **Instance**   | SAC address for native XLM                                          | Low — bumped automatically on every invocation                                       |
+
+#### NftReward (`contracts/nft-reward/src/lib.rs`)
+
+| Storage Key            | Type           | Description                                         | Eviction risk                                              |
+| ---------------------- | -------------- | --------------------------------------------------- | ---------------------------------------------------------- |
+| `DataKey::Nft(nft_id)` | **Persistent** | `NftData` struct (owner, hunt_id, player, metadata) | High — evicted NFTs appear burned to any off-chain indexer |
+| `DataKey::NftCount`    | **Instance**   | Monotonic counter for NFT IDs                       | Low — bumped automatically                                 |
+
+### TTL Bump Strategy
+
+#### What "bumping" means
+
+Calling `env.storage().persistent().extend_ttl(&key, threshold, extend_to)` restores the remaining
+TTL of a persistent entry to `extend_to` ledgers **only if** its current remaining TTL has fallen
+below `threshold`. This prevents unnecessary writes and keeps fees low.
+
+#### Recommended bump constants
+
+Define these in a shared `ttl.rs` (or at the top of `storage.rs`) per contract:
+
+```rust
+/// Minimum remaining TTL before we extend (≈ 30 days at 5s/ledger).
+pub const TTL_BUMP_THRESHOLD: u32 = 518_400;
+
+/// Target TTL after a bump (≈ 1 year at 5s/ledger).
+pub const TTL_BUMP_TARGET: u32 = 6_307_200;
+```
+
+> **Calibration note**: Stellar's ledger closes approximately every 5 seconds, giving ~6 307 200
+> ledgers per year. Adjust `TTL_BUMP_TARGET` to match the expected lifetime of the data (e.g. a
+> 90-day hunt needs at minimum 90 days × 17 280 ledgers/day ≈ 1 555 200 ledgers).
+
+#### Where to call `extend_ttl`
+
+Bump persistent storage entries at **read time** (inside helper getters in `storage.rs`), not only
+at write time. This ensures that data accessed frequently during active hunts keeps its TTL refreshed
+without any additional operator intervention.
+
+**Pattern — bump-on-read in `storage.rs`:**
+
+```rust
+pub fn get_hunt(env: &Env, hunt_id: u64) -> Option<Hunt> {
+    let key = DataKey::Hunt(hunt_id);
+    let result = env.storage().persistent().get::<DataKey, Hunt>(&key);
+    if result.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            TTL_BUMP_THRESHOLD,
+            TTL_BUMP_TARGET,
+        );
+    }
+    result
+}
+
+pub fn get_player_progress(env: &Env, hunt_id: u64, player: &Address) -> Option<PlayerProgress> {
+    let key = DataKey::PlayerProgress(hunt_id, player.clone());
+    let result = env.storage().persistent().get::<DataKey, PlayerProgress>(&key);
+    if result.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            TTL_BUMP_THRESHOLD,
+            TTL_BUMP_TARGET,
+        );
+    }
+    result
+}
+```
+
+**Pattern — bump-on-write:**
+
+```rust
+pub fn set_hunt(env: &Env, hunt_id: u64, hunt: &Hunt) {
+    let key = DataKey::Hunt(hunt_id);
+    env.storage().persistent().set(&key, hunt);
+    env.storage().persistent().extend_ttl(
+        &key,
+        TTL_BUMP_THRESHOLD,
+        TTL_BUMP_TARGET,
+    );
+}
+```
+
+#### Instance storage bump
+
+Instance storage is bumped automatically whenever the contract is invoked, but you may also bump it
+explicitly at the top of each contract function for extra safety:
+
+```rust
+env.storage().instance().extend_ttl(TTL_BUMP_THRESHOLD, TTL_BUMP_TARGET);
+```
+
+### Operator Runbook — Monitoring & Manual Bumps
+
+Even with bump-on-read in place, operators should monitor storage TTLs independently, because:
+
+- **Inactive hunts** (no player activity for weeks) will not trigger bump-on-read.
+- **Reward pools** for future hunts may sit idle for months before the hunt is activated.
+
+#### Checking remaining TTL via Stellar CLI
+
+```bash
+# Check the TTL of a specific contract data entry (persistent)
+stellar contract data get \
+  --id <CONTRACT_ID> \
+  --key '<XDR_KEY>' \
+  --network mainnet \
+  --durability persistent
+
+# The response includes `live_until_ledger`. Compare to current ledger:
+stellar ledgers --network mainnet | jq '.sequence'
+```
+
+#### Manually bumping an entry
+
+If an entry's TTL is dangerously low, bump it using a `restore_footprint` or `extend_footprint_ttl`
+operation before it expires:
+
+```bash
+# Extend the contract instance (covers all instance-storage keys)
+stellar contract extend \
+  --id <CONTRACT_ID> \
+  --ledgers-to-extend 6307200 \
+  --source <ADMIN_KEYPAIR> \
+  --network mainnet \
+  --durability persistent
+```
+
+> The `stellar contract extend` command targets the contract instance entry. To bump individual
+> persistent data entries (e.g. a specific `RewardPool`), you currently need a dedicated contract
+> invocation that calls `extend_ttl` internally, or use the Stellar SDK to construct a
+> `BumpFootprintExpirationOp` directly.
+
+#### Recommended monitoring schedule
+
+| Data category                                 | Check frequency           | Alert threshold         |
+| --------------------------------------------- | ------------------------- | ----------------------- |
+| Active hunt data (Hunt, Clue, PlayerProgress) | Daily during active hunts | < 7 days remaining TTL  |
+| Reward pools for scheduled hunts              | Weekly                    | < 30 days remaining TTL |
+| NFT records                                   | Monthly                   | < 60 days remaining TTL |
+| Instance storage (all contracts)              | Monthly                   | < 30 days remaining TTL |
+
+### Known Risks & Edge Cases
+
+| Risk                       | Scenario                                                                                               | Mitigation                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| **Silent answer lock-out** | `Clue` entries expire mid-hunt; players receive a storage-miss error on `submit_answer`                | Bump clue entries in `add_clue` and in `get_clue`; alert if TTL < 7 days                         |
+| **Lost player progress**   | `PlayerProgress` entry expires before `complete_hunt` is called                                        | Bump in `register_player`, `submit_answer`, and `complete_hunt`                                  |
+| **Reward pool eviction**   | `RewardPool` expires before hunt is completed and rewards are distributed; `distribute_rewards` panics | Bump `RewardPool` when pool is created and funded; set TTL to at least `hunt_end_date + 90 days` |
+| **Orphaned NFT**           | `Nft(nft_id)` entry expires; NFT appears burned to off-chain tools but is actually archivable          | Bump on mint; schedule periodic operator bump for all NFT IDs                                    |
+| **Hunt-count desync**      | `HuntCount` (instance) expires and resets; new hunts get IDs that collide with old data                | Instance storage is bumped on every invocation — this risk is negligible in practice             |
+
+### References
+
+- [Soroban Storage & State Archival Documentation](https://developers.stellar.org/docs/learn/encyclopedia/storage/state-archival)
+- [Stellar Network Settings (live TTL values)](https://stellar.expert/explorer/mainnet/network-settings)
+- [BumpFootprintExpirationOp XDR reference](https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/operations-and-transactions)
+
+---
 
 ## Development Workflow
 
 ### Working on a Feature
 
 1. **Create a feature branch:**
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+
+```bash
+git checkout -b feature/your-feature-name
+```
 
 2. **Make changes:**
+
    - Edit source files
    - Add tests
    - Update documentation
 
 3. **Test your changes:**
-   ```bash
-   make test
-   make build
-   ```
+
+```bash
+make test
+make build
+```
 
 4. **Format code:**
-   ```bash
-   make fmt
-   ```
+
+```bash
+make fmt
+```
 
 5. **Commit and push:**
-   ```bash
-   git add .
-   git commit -m "feat: description of changes"
-   git push origin feature/your-feature-name
-   ```
+
+```bash
+git add .
+git commit -m "feat: description of changes"
+git push origin feature/your-feature-name
+```
 
 ### Running Tests
 
 **Individual contract tests:**
+
 ```bash
 cd contracts/hunty-core
 cargo test
 ```
 
 **All tests:**
+
 ```bash
 cargo test --workspace
 ```
 
 **With output:**
+
 ```bash
 cargo test -- --nocapture
 ```
@@ -121,12 +342,14 @@ cargo test -- --nocapture
 ### Building Contracts
 
 **Build a single contract:**
+
 ```bash
 cd contracts/hunty-core
 make build
 ```
 
 **Build all contracts:**
+
 ```bash
 # From project root
 for dir in contracts/*/; do
@@ -135,6 +358,7 @@ done
 ```
 
 **Check build output:**
+
 ```bash
 ls -lh target/wasm32-unknown-unknown/release/*.wasm
 ```
@@ -144,6 +368,7 @@ ls -lh target/wasm32-unknown-unknown/release/*.wasm
 ### HuntyCore Contract
 
 **File Structure:**
+
 - `lib.rs` - Main contract implementation
 - `types.rs` - Data structures (Hunt, Clue, PlayerProgress)
 - `storage.rs` - Storage access patterns
@@ -151,6 +376,7 @@ ls -lh target/wasm32-unknown-unknown/release/*.wasm
 - `test.rs` - Test suite
 
 **Key Functions to Implement:**
+
 - `create_hunt()` - Create new hunt
 - `add_clue()` - Add clue to hunt
 - `register_player()` - Register player for hunt
@@ -160,12 +386,14 @@ ls -lh target/wasm32-unknown-unknown/release/*.wasm
 ### RewardManager Contract
 
 **File Structure:**
+
 - `lib.rs` - Main reward distribution logic
 - `xlm_handler.rs` - XLM token handling
 - `nft_handler.rs` - NFT coordination
 - `test.rs` - Test suite
 
 **Key Functions to Implement:**
+
 - `distribute_rewards()` - Main distribution entry
 - `handle_xlm_rewards()` - XLM transfer logic
 - `handle_nft_rewards()` - NFT minting coordination
@@ -173,10 +401,12 @@ ls -lh target/wasm32-unknown-unknown/release/*.wasm
 ### NftReward Contract
 
 **File Structure:**
+
 - `lib.rs` - NFT contract implementation
 - `test.rs` - Test suite
 
 **Key Functions to Implement:**
+
 - `mint_reward_nft()` - Mint NFT for reward
 - `transfer_nft()` - Transfer NFT to player
 - `get_nft_metadata()` - Retrieve NFT info
@@ -186,6 +416,7 @@ ls -lh target/wasm32-unknown-unknown/release/*.wasm
 ### Unit Tests
 
 Test individual functions:
+
 ```rust
 #[test]
 fn test_create_hunt() {
@@ -197,6 +428,7 @@ fn test_create_hunt() {
 ### Integration Tests
 
 Test cross-contract interactions:
+
 ```rust
 #[test]
 fn test_reward_distribution() {
@@ -207,6 +439,7 @@ fn test_reward_distribution() {
 ### Test Coverage
 
 Aim for >80% code coverage. Run:
+
 ```bash
 cargo test --workspace -- --nocapture
 ```
@@ -216,25 +449,30 @@ cargo test --workspace -- --nocapture
 ### Common Issues
 
 1. **Build errors:**
+
    - Check Rust version: `rustc --version`
    - Clean and rebuild: `make clean && make build`
 
 2. **Test failures:**
+
    - Run with output: `cargo test -- --nocapture`
    - Check error messages carefully
 
 3. **Storage issues:**
    - Verify storage keys are unique
    - Check data serialization
+   - **Check TTL** — see [Storage Architecture & TTL Management](#storage-architecture--ttl-management)
 
 ### Debug Tools
 
 **Print debugging:**
+
 ```rust
 env.logs().add("Debug message", &value);
 ```
 
 **Check storage:**
+
 ```rust
 // In tests
 let stored_value = env.storage().get(&key);
@@ -245,6 +483,7 @@ let stored_value = env.storage().get(&key);
 ### Formatting
 
 Always format before committing:
+
 ```bash
 make fmt
 # or
@@ -261,13 +500,14 @@ cargo fmt --all
 ### Documentation
 
 Add doc comments:
+
 ```rust
 /// Creates a new hunt with the given parameters.
-/// 
+///
 /// # Arguments
 /// * `env` - The environment
 /// * `creator` - Address of the hunt creator
-/// 
+///
 /// # Returns
 /// Hunt ID
 pub fn create_hunt(env: Env, creator: Address) -> u64 {
@@ -283,15 +523,18 @@ Hunty requires deploying three contracts in the correct order and wiring them to
 
 1. **Stellar CLI** installed and on your PATH (`stellar --version`).
 2. A funded deployer keypair. On testnet, use the friendbot:
-   ```bash
-   stellar keys generate deployer --network testnet
-   stellar keys fund deployer --network testnet
-   ```
+
+```bash
+stellar keys generate deployer --network testnet
+stellar keys fund deployer --network testnet
+```
+
 3. All contracts built (`.wasm` files present):
-   ```bash
-   cargo build --target wasm32-unknown-unknown --release
-   ls target/wasm32-unknown-unknown/release/*.wasm
-   ```
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+ls target/wasm32-unknown-unknown/release/*.wasm
+```
 
 ### Step 1 — Deploy NftReward
 
@@ -321,10 +564,10 @@ echo "RewardManager: $REWARD_MANAGER"
 
 The XLM Stellar Asset Contract address differs by network.
 
-| Network  | XLM SAC address |
-|----------|----------------|
-| Testnet  | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
-| Mainnet  | `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA` |
+| Network | XLM SAC address                                            |
+| ------- | ---------------------------------------------------------- |
+| Testnet | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
+| Mainnet | `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA` |
 
 > Tip: verify with `stellar contract id asset --asset native --network testnet`.
 
@@ -455,6 +698,7 @@ stellar contract invoke \
 - Use the mainnet XLM SAC: `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`.
 - Verify each contract ID with `stellar contract info --id <ID> --network mainnet` before calling `initialize`.
 - Keep `.env.mainnet` out of version control (add it to `.gitignore`).
+- **Review the [Storage Architecture & TTL Management](#storage-architecture--ttl-management) section** and confirm bump-on-read is implemented before deploying.
 
 ## Resources
 
@@ -467,5 +711,3 @@ stellar contract invoke \
 - Check [ARCHITECTURE.md](ARCHITECTURE.md) for system design
 - Review [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines
 - Open an issue on GitHub for questions
-
-


### PR DESCRIPTION
## docs: document Soroban storage TTL architecture and eviction risks

Closes #163 

---

### Summary of the Issue

The project had no documentation explaining Soroban's TTL / rent model,
which storage tier (instance vs persistent) each key belongs to, or what
operators need to do to prevent on-chain data from being silently archived.
This is a correctness risk in production: reward pools, player progress, and
clue answer hashes stored in `persistent` storage can all be evicted by the
network if their TTL is not periodically extended (bumped).

---

### Root Cause

Soroban persistent storage entries are **not** kept alive automatically.
They expire after a network-configured number of ledgers (~120 days on
mainnet at the time of writing) unless a `extend_ttl` call resets their
counter. The Hunty codebase uses persistent storage for hunt data, clue
hashes, player progress, and reward pools — all of which are long-lived and
critical to game correctness — but no documentation communicated this
behaviour to operators or contributors.

---

### Solution Implemented

Added a comprehensive **"Storage Architecture & TTL Management"** section to
`DEVELOPMENT.md`. No Rust source changes were made; this is a pure
documentation fix for a documentation issue.

---

### Key Changes Made

**`DEVELOPMENT.md`** — new top-level section inserted after the Quick Start
block, covering:

- **Soroban Storage Types Primer**: comparison table of instance, persistent,
  and temporary storage with default TTL behaviour and intended use cases.

- **Key → Storage Type Mapping**: per-contract tables documenting every
  storage key, its storage tier, description, and eviction risk level for
  HuntyCore, RewardManager, and NftReward.

- **TTL Bump Strategy**: recommended `TTL_BUMP_THRESHOLD` and
  `TTL_BUMP_TARGET` constants (calibrated to ~30 days threshold / ~1 year
  target), plus ready-to-copy Rust snippets for the bump-on-read and
  bump-on-write patterns.

- **Operator Runbook**: Stellar CLI commands for inspecting remaining TTL and
  manually extending entries; a monitoring schedule table (daily/weekly/
  monthly by data category).

- **Known Risks & Edge Cases**: a risk register covering silent answer
  lock-out, lost player progress, reward pool eviction, orphaned NFTs, and
  the (low) hunt-count desync scenario.

Two existing sections were also lightly updated:
- "Debugging → Storage issues" now includes a pointer to the new section.
- "Mainnet checklist" now includes a reminder to review TTL documentation
  before deploying.

---

### Trade-offs / Considerations

- **No code changes**: bump-on-read/write patterns are documented with code
  examples but not yet wired into the contracts themselves. A follow-up issue
  should track implementing these in `storage.rs` for each contract. The
  documentation accurately describes the *intended* pattern so contributors
  can implement it consistently.

- **TTL constants are approximate**: exact ledger counts are
  governance-controlled and can change. The documentation notes this
  explicitly and links to Stellar Network Settings for live values.

- **Temporary storage**: documented as "never use for game state" to prevent
  future misuse (temporary entries auto-delete and are not archivable).

---

### Testing Steps (How to Verify the Fix)

Since this is a documentation-only change, verification is editorial:

1. Checkout the branch and open `DEVELOPMENT.md`.
2. Confirm the new section "Storage Architecture & TTL Management" appears
   directly after the Quick Start block and before "Development Workflow".
3. Verify the Key → Storage Type Mapping tables list keys that match the
   `DataKey` enums in each contract's `storage.rs` / `lib.rs`.
4. Confirm the Rust code snippets compile (copy into a local Soroban project
   and run `cargo check`).
5. Confirm the Stellar CLI commands in the Operator Runbook are syntactically
   correct against the current Stellar CLI version (`stellar --version`).
6. Verify no existing content was accidentally removed by diffing against
   the previous `DEVELOPMENT.md`.

Thank you very much!!