### PR TITLE
feat(reward-manager): allow partial withdrawals in admin_withdraw_unclaimed

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -483,7 +483,11 @@ impl RewardManager {
         admin: Address,
         hunt_id: u64,
         recipient: Address,
+        amount: i128,
     ) -> Result<(), RewardErrorCode> {
+        if amount < 0 {
+            return Err(RewardErrorCode::InvalidAmount);
+        }
         admin.require_auth();
 
         let configured_admin = Storage::get_admin(&env).ok_or(RewardErrorCode::NotInitialized)?;
@@ -495,7 +499,13 @@ impl RewardManager {
         Storage::get_pool_config(&env, hunt_id).ok_or(RewardErrorCode::PoolNotFound)?;
 
         let balance = Storage::get_pool_balance(&env, hunt_id);
-        if balance == 0 {
+        let withdraw_amount = if amount == 0 {
+            balance
+        } else {
+            amount
+        };
+
+        if withdraw_amount <= 0 || withdraw_amount > balance {
             return Err(RewardErrorCode::InvalidAmount);
         }
 
@@ -503,16 +513,16 @@ impl RewardManager {
 
         let contract_addr = env.current_contract_address();
         let client = soroban_sdk::token::Client::new(&env, &xlm_token);
-        client.transfer(&contract_addr, &recipient, &balance);
+        client.transfer(&contract_addr, &recipient, &withdraw_amount);
 
-        Storage::set_pool_balance(&env, hunt_id, 0);
+        Storage::set_pool_balance(&env, hunt_id, balance - withdraw_amount);
 
         env.events().publish(
             (symbol_short!("ADM_WDR"), hunt_id),
             AdminWithdrawEvent {
                 hunt_id,
                 admin,
-                amount: balance,
+                amount: withdraw_amount,
             },
         );
 

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -976,6 +976,7 @@ mod test {
                 admin.clone(),
                 1,
                 recipient.clone(),
+                0,
             );
             assert!(result.is_ok());
 
@@ -1009,6 +1010,7 @@ mod test {
                 non_admin.clone(),
                 1,
                 non_admin.clone(),
+                0,
             );
             assert_eq!(result, Err(RewardErrorCode::Unauthorized));
 
@@ -1034,6 +1036,7 @@ mod test {
                 admin.clone(),
                 99,
                 recipient.clone(),
+                0,
             );
             assert_eq!(result, Err(RewardErrorCode::PoolNotFound));
         });
@@ -1068,6 +1071,7 @@ mod test {
                 admin.clone(),
                 1,
                 recipient.clone(),
+                0,
             );
             assert_eq!(result, Err(RewardErrorCode::InvalidAmount));
         });
@@ -1091,8 +1095,86 @@ mod test {
                 admin.clone(),
                 1,
                 recipient.clone(),
+                0,
             );
             assert_eq!(result, Err(RewardErrorCode::NotInitialized));
         });
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_partial_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let player = Address::generate(&env);
+
+        mint_tokens(&env, &token_address, &token_admin, &creator, 10_000);
+
+        let client = crate::RewardManagerClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &token_address);
+        client.create_reward_pool(&creator, &1, &0);
+        client.fund_reward_pool(&creator, &1, &6_000);
+
+        // Distribute to one player, leaving 4_000 unclaimed
+        client.distribute_rewards(&1, &player, &xlm_only_config(&env, 2_000));
+
+        // Admin partially withdraws 1_500 to recipient
+        let result = client.try_admin_withdraw_unclaimed(&admin, &1, &recipient, &1_500);
+        assert!(result.is_ok());
+
+        // Pool balance should now be 2_500
+        assert_eq!(client.get_pool_balance(&1), 2_500);
+
+        // Admin withdraws the remaining balance using 0
+        let result2 = client.try_admin_withdraw_unclaimed(&admin, &1, &recipient, &0);
+        assert!(result2.is_ok());
+        assert_eq!(client.get_pool_balance(&1), 0);
+
+        // Recipient should have received 4_000 in total
+        assert_eq!(get_balance(&env, &token_address, &recipient), 4_000);
+    }
+
+    #[test]
+    fn test_admin_withdraw_unclaimed_invalid_amount_partial() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_address, token_admin) = setup(&env);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let player = Address::generate(&env);
+
+        mint_tokens(&env, &token_address, &token_admin, &creator, 10_000);
+
+        let client = crate::RewardManagerClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &token_address);
+        client.create_reward_pool(&creator, &1, &0);
+        client.fund_reward_pool(&creator, &1, &6_000);
+
+        // Distribute to one player, leaving 4_000 unclaimed
+        client.distribute_rewards(&1, &player, &xlm_only_config(&env, 2_000));
+
+        // Try to withdraw negative amount
+        let result_neg = client.try_admin_withdraw_unclaimed(
+            &admin,
+            &1,
+            &recipient,
+            &-500,
+        );
+        assert!(result_neg.is_err()); // should fail with InvalidAmount or similar host error
+
+        // Try to withdraw more than remaining balance (4_500 > 4_000)
+        let result_excess = client.try_admin_withdraw_unclaimed(
+            &admin,
+            &1,
+            &recipient,
+            &4_500,
+        );
+        assert!(result_excess.is_err());
     }
 }


### PR DESCRIPTION
### Description
- Updates the `admin_withdraw_unclaimed` function in `reward-manager` to accept an `amount` parameter.
- Passing `amount = 0` maintains the default behavior of draining the entire remaining pool balance.
- Passing a positive `amount` allows partial withdrawals of the exact amount specified (validates `amount <= balance`).
- Rejects invalid withdrawals (such as negative amounts or amounts exceeding the remaining balance) with `RewardErrorCode::InvalidAmount`.
- Updates existing tests to pass `0` to maintain original tests.
- Adds new tests (`test_admin_withdraw_unclaimed_partial_success` and `test_admin_withdraw_unclaimed_invalid_amount_partial`) to cover the new partial withdrawal logic and validation rules.

### Verification
- Verified that the new tests compile and pass successfully.

closes #140