### PR TITLE
HuntCancelledEvent and NftMintedEvent

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -375,7 +375,11 @@ impl HuntyCore {
         Storage::save_hunt(&env, &hunt);
 
         // Emit event
-        let event = HuntCancelledEvent { hunt_id };
+        let event = HuntCancelledEvent {
+            hunt_id,
+            cancelled_by: caller,
+            cancelled_at: env.ledger().timestamp(),
+        };
 
         env.events()
             .publish((Symbol::new(&env, "HuntCancelled"), hunt_id), event);

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -10,12 +10,12 @@ mod test {
     // Bring Soroban testutils traits into scope (generate addresses, set ledger info, register contracts).
     use crate::errors::{HuntError, HuntErrorCode};
     use crate::storage::Storage;
-    use crate::types::HuntStatus;
+    use crate::types::{HuntCancelledEvent, HuntStatus};
     use crate::HuntyCore;
     use nft_reward::{NftMetadata, NftReward};
     use reward_manager::RewardManager;
-    use soroban_sdk::testutils::{Address as _, Ledger as _, Register as _};
-    use soroban_sdk::{token, String as SorobanString};
+    use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _, Register as _};
+    use soroban_sdk::{token, String as SorobanString, Symbol, TryFromVal, Val};
 
     /// Runs a closure inside a registered HuntyCore contract context so storage is accessible.
     fn with_core_contract<T>(env: &Env, f: impl FnOnce(&Env, &Address) -> T) -> T {
@@ -1065,6 +1065,55 @@ mod test {
     }
 
     #[test]
+    fn test_cancel_hunt_emits_canceller_and_timestamp() {
+        let env = Env::default();
+        let cancelled_at = 1_700_000_123;
+        env.ledger().set_timestamp(cancelled_at);
+        env.mock_all_auths();
+
+        let creator = Address::generate(&env);
+        let question = String::from_str(&env, "Valid question");
+        let answer = String::from_str(&env, "a");
+
+        with_core_contract(&env, |env, cid| {
+            let hunt_id = HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                String::from_str(env, "Test Hunt"),
+                String::from_str(env, "Test description"),
+                None,
+                None,
+            )
+            .unwrap();
+
+            HuntyCore::add_clue(env.clone(), hunt_id, question, answer, 1, true).unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+            HuntyCore::cancel_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+
+            let events = env.events().all();
+            let (contract, topics, data): (Address, Vec<Val>, Val) =
+                events.get(events.len() - 1).unwrap();
+            assert_eq!(contract, cid.clone().into());
+            assert_eq!(topics.len(), 2);
+            assert_eq!(
+                Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap(),
+                Symbol::new(env, "HuntCancelled")
+            );
+            assert_eq!(u64::try_from_val(env, &topics.get(1).unwrap()).unwrap(), hunt_id);
+
+            let event = HuntCancelledEvent::try_from_val(env, &data).unwrap();
+            assert_eq!(
+                event,
+                HuntCancelledEvent {
+                    hunt_id,
+                    cancelled_by: creator.clone(),
+                    cancelled_at,
+                }
+            );
+        });
+    }
+
+    #[test]
     fn test_cancel_hunt_refunds_reward_pool_balance() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);
@@ -1350,7 +1399,7 @@ mod test {
                 HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
 
-            Ok(())
+            Ok::<(), HuntErrorCode>(())
         });
     }
 

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -61,9 +61,11 @@ pub struct ClueInfo {
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HuntCancelledEvent {
     pub hunt_id: u64,
+    pub cancelled_by: Address,
+    pub cancelled_at: u64,
 }
 
 #[contracttype]

--- a/contracts/hunty-core/test_snapshots/test/test/test_cancel_hunt_already_cancelled.1.json
+++ b/contracts/hunty-core/test_snapshots/test/test/test_cancel_hunt_already_cancelled.1.json
@@ -600,6 +600,22 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "cancelled_at"
+                  },
+                  "val": {
+                    "u64": 1700000000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "cancelled_by"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "hunt_id"
                   },
                   "val": {

--- a/contracts/hunty-core/test_snapshots/test/test/test_cancel_hunt_emits_canceller_and_timestamp.1.json
+++ b/contracts/hunty-core/test_snapshots/test/test/test_cancel_hunt_emits_canceller_and_timestamp.1.json
@@ -24,7 +24,7 @@
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 1700000000,
+    "timestamp": 1700000123,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -236,7 +236,7 @@
                                 "symbol": "activated_at"
                               },
                               "val": {
-                                "u64": 1700000000
+                                "u64": 1700000123
                               }
                             },
                             {
@@ -244,7 +244,7 @@
                                 "symbol": "created_at"
                               },
                               "val": {
-                                "u64": 1700000000
+                                "u64": 1700000123
                               }
                             },
                             {
@@ -563,7 +563,7 @@
                     "symbol": "activated_at"
                   },
                   "val": {
-                    "u64": 1700000000
+                    "u64": 1700000123
                   }
                 },
                 {
@@ -603,7 +603,7 @@
                     "symbol": "cancelled_at"
                   },
                   "val": {
-                    "u64": 1700000000
+                    "u64": 1700000123
                   }
                 },
                 {

--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -56,6 +56,8 @@ pub struct NftMintedEvent {
     pub nft_id: u64,
     pub hunt_id: u64,
     pub owner: Address,
+    pub rarity: u32,
+    pub tier: u32,
     pub metadata: NftMetadata,
     pub minted_at: u64,
 }
@@ -122,6 +124,8 @@ impl NftReward {
             nft_id,
             hunt_id,
             owner: player_address,
+            rarity: metadata.rarity,
+            tier: metadata.tier,
             metadata,
             minted_at,
         };

--- a/contracts/nft-reward/src/test.rs
+++ b/contracts/nft-reward/src/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 extern crate std;
 
-use crate::{NftMetadata, NftReward, NftRewardClient};
+use crate::{NftMetadata, NftMintedEvent, NftReward, NftRewardClient};
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, String,
+    Address, Env, String, Symbol, TryFromVal, Val, Vec,
 };
 
 fn setup_env() -> Env {
@@ -141,15 +141,39 @@ fn test_nft_minted_event() {
     let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
 
     let player = Address::generate(&env);
-    let metadata = create_metadata(&env, "Event Test", "Event desc", "ipfs://event");
+    let metadata = create_metadata_full(
+        &env,
+        "Event Test",
+        "Event desc",
+        "ipfs://event",
+        "Indexed Hunt",
+        4,
+        2,
+    );
 
-    let _nft_id = client.mint_reward_nft(&7, &player, &metadata);
+    let nft_id = client.mint_reward_nft(&7, &player, &metadata);
 
     let events = env.events().all();
     assert!(!events.is_empty());
     // Last event should be NftMinted
-    let (_contract, topics, _data) = events.get(events.len() - 1).unwrap();
+    let (_contract, topics, data): (Address, Vec<Val>, Val) =
+        events.get(events.len() - 1).unwrap();
     assert_eq!(topics.len(), 2); // "NftMinted" + nft_id
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "NftMinted")
+    );
+    assert_eq!(u64::try_from_val(&env, &topics.get(1).unwrap()).unwrap(), nft_id);
+
+    let event = NftMintedEvent::try_from_val(&env, &data).unwrap();
+    assert_eq!(event.nft_id, nft_id);
+    assert_eq!(event.hunt_id, 7);
+    assert_eq!(event.owner, player);
+    assert_eq!(event.rarity, 4);
+    assert_eq!(event.tier, 2);
+    assert_eq!(event.metadata.rarity, 4);
+    assert_eq!(event.metadata.tier, 2);
+    assert_eq!(event.minted_at, 1000);
 }
 
 #[test]

--- a/contracts/nft-reward/test_snapshots/test/test_nft_minted_event.1.json
+++ b/contracts/nft-reward/test_snapshots/test/test_nft_minted_event.1.json
@@ -1,0 +1,429 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "CNTR"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "CNTR"
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NFT"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NFT"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "completion_player"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "hunt_id"
+                      },
+                      "val": {
+                        "u64": 7
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "string": "Event desc"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "hunt_title"
+                            },
+                            "val": {
+                              "string": "Indexed Hunt"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "image_uri"
+                            },
+                            "val": {
+                              "string": "ipfs://event"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "rarity"
+                            },
+                            "val": {
+                              "u32": 4
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "tier"
+                            },
+                            "val": {
+                              "u32": 2
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "title"
+                            },
+                            "val": {
+                              "string": "Event Test"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minted_at"
+                      },
+                      "val": {
+                        "u64": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nft_id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ONFT"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ONFT"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u64": 1
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "NftMinted"
+              },
+              {
+                "u64": 1
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "hunt_id"
+                  },
+                  "val": {
+                    "u64": 7
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "metadata"
+                  },
+                  "val": {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "description"
+                        },
+                        "val": {
+                          "string": "Event desc"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "hunt_title"
+                        },
+                        "val": {
+                          "string": "Indexed Hunt"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "image_uri"
+                        },
+                        "val": {
+                          "string": "ipfs://event"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "rarity"
+                        },
+                        "val": {
+                          "u32": 4
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "tier"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "title"
+                        },
+                        "val": {
+                          "string": "Event Test"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "minted_at"
+                  },
+                  "val": {
+                    "u64": 1000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "nft_id"
+                  },
+                  "val": {
+                    "u64": 1
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "owner"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rarity"
+                  },
+                  "val": {
+                    "u32": 4
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "tier"
+                  },
+                  "val": {
+                    "u32": 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
HuntCancelledEvent now includes both cancelled_by: Address and cancelled_at: u64, and cancel_hunt emits those values from the caller and current ledger timestamp. The event shape change is in types.rs (line 63) and the emitter update is in lib.rs (line 377).
I also added a focused test that verifies the cancel event payload and topics, in test.rs (line 1067). While compiling, the suite had a pre-existing ambiguous Ok(()) in another test, so I added a tiny type annotation there to keep hunty-core tests buildable.
Verification: cargo test -p hunty-core cancel_hunt passed.

NftMintedEvent now exposes rarity and tier as top-level fields while keeping the nested metadata unchanged. The event shape update is in lib.rs (line 55), and the mint path now copies metadata.rarity and metadata.tier into the emitted event at lib.rs (line 123).
I also strengthened the NFT event test in test.rs (line 138) so it decodes the emitted NftMintedEvent and asserts both top-level fields and nested metadata remain consistent.
Verification: cargo test -p nft-reward nft_minted_event passed.