### PR TITLE
feat(nft-reward): add configurable max supply cap

### DIFF
--- a/contracts/nft-reward/src/errors.rs
+++ b/contracts/nft-reward/src/errors.rs
@@ -10,4 +10,6 @@ pub enum NftErrorCode {
     InvalidRecipient = 4,
     SoulboundNft = 5,
     InvalidRarity = 6,
+    AlreadyInitialized = 7,
+    MaxSupplyReached = 8,
 }

--- a/contracts/nft-reward/src/lib.rs
+++ b/contracts/nft-reward/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, Address, Env, Map, String, Symbol, Val, Vec,
+    contract, contractimpl, contracttype, panic_with_error, Address, Env, Map, String, Symbol,
+    Val, Vec,
 };
 
 /// Core display metadata for an NFT (title, description, image URI).
@@ -87,6 +88,17 @@ pub struct NftReward;
 
 #[contractimpl]
 impl NftReward {
+    /// Initializes the NFT reward contract with an optional max supply cap.
+    /// Call this once if you want to enforce a finite NFT supply.
+    pub fn initialize(env: Env, max_supply: Option<u64>) -> Result<(), crate::errors::NftErrorCode> {
+        if Storage::is_initialized(&env) {
+            return Err(crate::errors::NftErrorCode::AlreadyInitialized);
+        }
+
+        Storage::set_max_supply(&env, max_supply);
+        Ok(())
+    }
+
     /// Mints a unique NFT as a reward for hunt completion.
     ///
     /// # Arguments
@@ -103,37 +115,7 @@ impl NftReward {
         player_address: Address,
         metadata: NftMetadata,
     ) -> u64 {
-        if metadata.rarity > 5 {
-            panic!("InvalidRarity");
-        }
-        let minted_at = env.ledger().timestamp();
-
-        let nft_id = Storage::next_nft_id(&env);
-
-        let nft_data = NftData {
-            nft_id,
-            hunt_id,
-            owner: player_address.clone(),
-            completion_player: player_address.clone(),
-            metadata: metadata.clone(),
-            transferable: false,
-            minted_at,
-        };
-
-        Storage::save_nft(&env, &nft_data);
-        Storage::add_nft_to_owner(&env, &player_address, nft_id);
-
-        let event = NftMintedEvent {
-            nft_id,
-            hunt_id,
-            owner: player_address,
-            metadata,
-            minted_at,
-        };
-        env.events()
-            .publish((Symbol::new(&env, "NftMinted"), nft_id), event);
-
-        nft_id
+        Self::mint_reward_nft_impl(env, hunt_id, player_address, metadata, false)
     }
 
     /// Mints a reward NFT from a generic metadata map. This is the entrypoint
@@ -203,6 +185,26 @@ impl NftReward {
             rarity,
             tier,
         };
+        Self::mint_reward_nft_impl(env, hunt_id, player_address, meta, transferable)
+    }
+
+    fn mint_reward_nft_impl(
+        env: Env,
+        hunt_id: u64,
+        player_address: Address,
+        metadata: NftMetadata,
+        transferable: bool,
+    ) -> u64 {
+        if metadata.rarity > 5 {
+            panic_with_error!(&env, crate::errors::NftErrorCode::InvalidRarity);
+        }
+
+        if let Some(max_supply) = Storage::get_max_supply(&env) {
+            let current_supply = Storage::get_nft_counter(&env);
+            if current_supply >= max_supply {
+                panic_with_error!(&env, crate::errors::NftErrorCode::MaxSupplyReached);
+            }
+        }
 
         let minted_at = env.ledger().timestamp();
         let nft_id = Storage::next_nft_id(&env);
@@ -212,7 +214,7 @@ impl NftReward {
             hunt_id,
             owner: player_address.clone(),
             completion_player: player_address.clone(),
-            metadata: meta.clone(),
+            metadata: metadata.clone(),
             transferable,
             minted_at,
         };
@@ -224,7 +226,7 @@ impl NftReward {
             nft_id,
             hunt_id,
             owner: player_address,
-            metadata: meta,
+            metadata,
             minted_at,
         };
         env.events()

--- a/contracts/nft-reward/src/storage.rs
+++ b/contracts/nft-reward/src/storage.rs
@@ -8,6 +8,8 @@ impl Storage {
     const NFT_KEY: soroban_sdk::Symbol = symbol_short!("NFT");
     const NFT_COUNTER_KEY: soroban_sdk::Symbol = symbol_short!("CNTR");
     const OWNER_NFT_COUNT_KEY: soroban_sdk::Symbol = symbol_short!("ONFC");
+    const MAX_SUPPLY_KEY: soroban_sdk::Symbol = symbol_short!("MAXS");
+    const INITIALIZED_KEY: soroban_sdk::Symbol = symbol_short!("INIT");
 
     fn nft_key(nft_id: u64) -> (soroban_sdk::Symbol, u64) {
         (Self::NFT_KEY, nft_id)
@@ -60,6 +62,28 @@ impl Storage {
             .persistent()
             .get(&Self::NFT_COUNTER_KEY)
             .unwrap_or(0)
+    }
+
+    /// Marks the contract initialized and stores the optional max supply cap.
+    pub fn set_max_supply(env: &Env, max_supply: Option<u64>) {
+        env.storage().persistent().set(&Self::MAX_SUPPLY_KEY, &max_supply);
+        env.storage().persistent().set(&Self::INITIALIZED_KEY, &true);
+    }
+
+    /// Returns the configured max supply cap, if one has been stored.
+    pub fn get_max_supply(env: &Env) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&Self::MAX_SUPPLY_KEY)
+            .unwrap_or(None)
+    }
+
+    /// Returns whether the contract has been initialized.
+    pub fn is_initialized(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&Self::INITIALIZED_KEY)
+            .unwrap_or(false)
     }
 
     /// Adds an NFT ID to the owner's index.

--- a/contracts/nft-reward/src/test.rs
+++ b/contracts/nft-reward/src/test.rs
@@ -14,6 +14,13 @@ fn setup_env() -> Env {
     env
 }
 
+fn setup_nft_reward(env: &Env, max_supply: Option<u64>) -> NftRewardClient<'_> {
+    let contract_id = env.register_contract(None, NftReward);
+    let client = NftRewardClient::new(env, &contract_id);
+    client.initialize(&max_supply);
+    client
+}
+
 fn create_metadata(env: &Env, title: &str, desc: &str, image_uri: &str) -> NftMetadata {
     NftMetadata {
         title: String::from_str(env, title),
@@ -47,7 +54,7 @@ fn create_metadata_full(
 #[test]
 fn test_mint_reward_nft() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(
@@ -86,7 +93,7 @@ fn create_transferable_metadata(env: &Env, title: &str, desc: &str, image_uri: &
 #[test]
 fn test_nft_ids_are_unique() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player1 = Address::generate(&env);
     let player2 = Address::generate(&env);
@@ -106,7 +113,7 @@ fn test_nft_ids_are_unique() {
 #[test]
 fn test_metadata_stored_correctly() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(
@@ -133,7 +140,7 @@ fn test_metadata_stored_correctly() {
 #[test]
 fn test_initial_ownership_set_correctly() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Trophy", "Trophy desc", "ipfs://trophy");
@@ -150,7 +157,7 @@ fn test_initial_ownership_set_correctly() {
 #[test]
 fn test_nft_minted_event() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Event Test", "Event desc", "ipfs://event");
@@ -167,7 +174,7 @@ fn test_nft_minted_event() {
 #[test]
 fn test_multiple_nfts_can_be_minted() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
 
@@ -193,7 +200,7 @@ fn test_multiple_nfts_can_be_minted() {
 #[test]
 fn test_nft_data_can_be_queried() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Query Test", "Query desc", "ipfs://query");
@@ -209,7 +216,7 @@ fn test_nft_data_can_be_queried() {
 #[test]
 fn test_get_nonexistent_nft_returns_none() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let nft = client.get_nft(&999);
     assert!(nft.is_none());
@@ -224,7 +231,7 @@ fn test_get_nonexistent_nft_returns_none() {
 #[test]
 fn test_get_nft_metadata_returns_complete_info() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata_full(
@@ -256,7 +263,7 @@ fn test_get_nft_metadata_returns_complete_info() {
 #[test]
 fn test_update_nft_metadata_owner_only() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let metadata = create_metadata(&env, "Original", "Original desc", "ipfs://old");
@@ -279,7 +286,7 @@ fn test_update_nft_metadata_owner_only() {
 #[test]
 fn test_update_nft_metadata_preserves_immutable_fields() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let metadata = create_metadata_full(&env, "Title", "Desc", "ipfs://img", "Hunt", 3, 2);
@@ -303,7 +310,7 @@ fn test_update_nft_metadata_preserves_immutable_fields() {
 #[test]
 fn test_transfer_nft_success() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
@@ -324,7 +331,7 @@ fn test_transfer_nft_success() {
 #[test]
 fn test_transfer_nft_updates_player_nfts() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
@@ -354,7 +361,7 @@ fn test_transfer_nft_requires_auth() {
     // Do NOT mock auth - we want the transfer to fail without auth
     env.ledger().set_timestamp(1000);
 
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
@@ -370,7 +377,7 @@ fn test_transfer_nft_requires_auth() {
 #[should_panic]
 fn test_transfer_nft_nonexistent() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
@@ -382,7 +389,7 @@ fn test_transfer_nft_nonexistent() {
 #[should_panic]
 fn test_transfer_nft_not_owner() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let attacker = Address::generate(&env);
@@ -399,7 +406,7 @@ fn test_transfer_nft_not_owner() {
 #[should_panic]
 fn test_transfer_nft_invalid_recipient_same_as_from() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let metadata = create_metadata(&env, "Same Addr", "Desc", "ipfs://same");
@@ -412,7 +419,7 @@ fn test_transfer_nft_invalid_recipient_same_as_from() {
 #[test]
 fn test_transfer_nft_emits_event() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let from = Address::generate(&env);
     let to = Address::generate(&env);
@@ -428,7 +435,7 @@ fn test_transfer_nft_emits_event() {
 #[test]
 fn test_get_player_nfts_empty_for_new_address() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let new_addr = Address::generate(&env);
     let nfts = client.get_player_nfts(&new_addr);
@@ -438,7 +445,7 @@ fn test_get_player_nfts_empty_for_new_address() {
 #[test]
 fn test_get_nft_owner_matches_owner_of() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let player = Address::generate(&env);
     let metadata = create_metadata(&env, "Alias Test", "Desc", "ipfs://alias");
@@ -452,7 +459,7 @@ fn test_get_nft_owner_matches_owner_of() {
 #[test]
 fn test_burn_removes_nft_and_clears_owner_list() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let metadata = create_metadata(&env, "Burn Me", "Desc", "ipfs://burn");
@@ -460,7 +467,7 @@ fn test_burn_removes_nft_and_clears_owner_list() {
     let nft_id = client.mint_reward_nft(&1, &owner, &metadata);
     assert!(client.get_nft(&nft_id).is_some());
 
-    client.burn(&nft_id, &owner).unwrap();
+    client.burn(&nft_id, &owner);
 
     assert!(client.get_nft(&nft_id).is_none());
     assert_eq!(client.get_player_nfts(&owner).len(), 0);
@@ -469,7 +476,7 @@ fn test_burn_removes_nft_and_clears_owner_list() {
 #[test]
 fn test_burn_fails_if_not_owner() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let other = Address::generate(&env);
@@ -486,9 +493,28 @@ fn test_burn_fails_if_not_owner() {
 #[test]
 fn test_burn_fails_for_nonexistent_nft() {
     let env = setup_env();
-    let client = NftRewardClient::new(&env, &env.register_contract(None, NftReward));
+    let client = setup_nft_reward(&env, None);
 
     let owner = Address::generate(&env);
     let result = client.try_burn(&999u64, &owner);
     assert!(result.is_err());
+}
+
+#[test]
+#[should_panic(expected = "HostError")]
+fn test_max_supply_cap_blocks_additional_mints() {
+    let env = setup_env();
+    let client = setup_nft_reward(&env, Some(2));
+
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let player3 = Address::generate(&env);
+
+    let metadata1 = create_metadata(&env, "NFT 1", "Desc 1", "ipfs://1");
+    let metadata2 = create_metadata(&env, "NFT 2", "Desc 2", "ipfs://2");
+    let metadata3 = create_metadata(&env, "NFT 3", "Desc 3", "ipfs://3");
+
+    client.mint_reward_nft(&1, &player1, &metadata1);
+    client.mint_reward_nft(&1, &player2, &metadata2);
+    client.mint_reward_nft(&1, &player3, &metadata3);
 }


### PR DESCRIPTION
## Overview
This PR adds a configurable max NFT supply cap to the NFT reward contract. Deployments can now set an optional `max_supply` at initialization, and minting stops once the configured cap is reached.

## Related Issue
Closes #139

## Changes
- Modified contracts/nft-reward/src/lib.rs
  - Added an `initialize(max_supply: Option<u64>)` entrypoint to configure the NFT supply cap.
  - Enforced the cap in both mint paths before creating a new NFT.
  - Kept unlimited minting available when no cap is configured.
- Modified contracts/nft-reward/src/storage.rs
  - Added persistent storage for the optional max supply and initialization state.
- Modified contracts/nft-reward/src/errors.rs
  - Added contract errors for repeated initialization and cap exhaustion.
- Modified contracts/nft-reward/src/test.rs
  - Added a regression test that initializes the contract with a cap of 2 and verifies the third mint fails.
  - Updated NFT test setup to initialize the contract consistently.

## Verification
- `cargo test -p nft-reward --lib -- --nocapture` ✅ passed (24/24)

