### PR TITLE
fix(reward-manager): derive distribution status from record

### DIFF
--- a/contracts/reward-manager/src/lib.rs
+++ b/contracts/reward-manager/src/lib.rs
@@ -436,17 +436,16 @@ impl RewardManager {
         hunt_id: u64,
         player: Address,
     ) -> DistributionStatus {
-        let distributed = Storage::is_distributed(&env, hunt_id, &player);
         let record = Storage::get_distribution_record(&env, hunt_id, &player);
 
         match record {
             Some(r) => DistributionStatus {
-                distributed,
+                distributed: true,
                 xlm_amount: r.xlm_amount,
                 nft_id: r.nft_id,
             },
             None => DistributionStatus {
-                distributed,
+                distributed: false,
                 xlm_amount: 0,
                 nft_id: None,
             },

--- a/contracts/reward-manager/src/nft_handler.rs
+++ b/contracts/reward-manager/src/nft_handler.rs
@@ -55,7 +55,7 @@ impl NftHandler {
         args.push_back(player.clone().into_val(env));
         args.push_back(metadata.into_val(env));
 
-        env.try_invoke_contract(
+        env.try_invoke_contract::<u64, RewardErrorCode>(
             nft_contract,
             &Symbol::new(env, "mint_reward_nft_from_map"),
             args,

--- a/contracts/reward-manager/src/test.rs
+++ b/contracts/reward-manager/src/test.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::types::RewardConfig;
     use crate::RewardManager;
     use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{token, Address, Env};
+    use soroban_sdk::{symbol_short, token, Address, Env};
 
     /// Registers the RewardManager contract and a mock SAC token.
     /// Returns (contract_id, token_address, token_admin).
@@ -853,6 +853,31 @@ mod test {
             // After distribution
             let config = xlm_only_config(&env, 2_000);
             RewardManager::distribute_rewards(env.clone(), 1, player.clone(), config).unwrap();
+
+            let status = RewardManager::get_distribution_status(env.clone(), 1, player.clone());
+            assert!(status.distributed);
+            assert_eq!(status.xlm_amount, 2_000);
+            assert_eq!(status.nft_id, None);
+        });
+    }
+
+    #[test]
+    fn test_get_distribution_status_ignores_stale_bool_flag() {
+        let env = Env::default();
+        let (contract_id, _, _) = setup(&env);
+        let player = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let record = crate::types::DistributionRecord {
+                xlm_amount: 2_000,
+                nft_id: None,
+            };
+            Storage::set_distribution_record(&env, 1, &player, &record);
+            Storage::set_distributed(&env, 1, &player);
+
+            // Simulate stale state: the record remains but the separate boolean flag disappears.
+            let dist_key = (symbol_short!("DIST"), 1u64, player.clone());
+            env.storage().persistent().remove(&dist_key);
 
             let status = RewardManager::get_distribution_status(env.clone(), 1, player.clone());
             assert!(status.distributed);


### PR DESCRIPTION
## Overview
This PR makes `get_distribution_status` derive its `distributed` state from the stored distribution record instead of the separate boolean flag. That prevents contradictory results when the `DIST` key and the distribution record expire independently.

## Related Issue
Closes #143

## Changes
- `get_distribution_status` now uses the distribution record as the source of truth.
- If a record exists, the status is reported as distributed with the recorded XLM amount and NFT id.
- If no record exists, the status is reported as not distributed with empty values.
- Added a regression test that removes the stale boolean key and confirms the status still reports the completed distribution correctly.
- Included a small Soroban SDK compatibility fix in `nft_handler.rs` so the reward-manager tests build cleanly in this environment.

## Verification
- `cargo test -p reward-manager --lib test_get_distribution_status_ignores_stale_bool_flag -- --nocapture` ✅
