### PR TITLE
feat(hunty-core): add time-based score bonuses

### DIFF
--- a/contracts/hunty-core/src/errors.rs
+++ b/contracts/hunty-core/src/errors.rs
@@ -28,6 +28,7 @@ pub enum HuntErrorCode {
     NoRewardsConfigured = 21,
     NoRequiredClues = 22,
     InvalidRarity = 23,
+    InvalidTimeBonusConfig = 24,
 }
 
 #[derive(Debug)]
@@ -53,6 +54,7 @@ pub enum HuntError {
     NoRewardsConfigured { hunt_id: u64 },
     NoRequiredClues { hunt_id: u64 },
     InvalidRarity { value: u32 },
+    InvalidTimeBonusConfig,
 }
 
 impl fmt::Display for HuntError {
@@ -128,6 +130,9 @@ impl fmt::Display for HuntError {
             HuntError::InvalidRarity { value } => {
                 write!(f, "Invalid nft_rarity {}: must be 0-5", value)
             }
+            HuntError::InvalidTimeBonusConfig => {
+                write!(f, "Invalid time bonus configuration")
+            }
         }
     }
 }
@@ -156,6 +161,7 @@ impl From<HuntError> for HuntErrorCode {
             HuntError::NoRewardsConfigured { .. } => HuntErrorCode::NoRewardsConfigured,
             HuntError::NoRequiredClues { .. } => HuntErrorCode::NoRequiredClues,
             HuntError::InvalidRarity { .. } => HuntErrorCode::InvalidRarity,
+            HuntError::InvalidTimeBonusConfig => HuntErrorCode::InvalidTimeBonusConfig,
         }
     }
 }

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -1,14 +1,14 @@
 #![no_std]
 extern crate alloc;
-use alloc::string::String as StdString;
 use crate::errors::{HuntError, HuntErrorCode};
 use crate::storage::Storage;
 use crate::types::{
     AnswerIncorrectEvent, Clue, ClueAddedEvent, ClueCompletedEvent, ClueInfo, ClueRemovedEvent,
     Hunt, HuntActivatedEvent, HuntCancelledEvent, HuntCompletedEvent, HuntCreatedEvent,
     HuntDeactivatedEvent, HuntStatistics, HuntStatus, LeaderboardEntry, PlayerProgress,
-    PlayerRegisteredEvent, RewardClaimedEvent, RewardConfig,
+    PlayerRegisteredEvent, RewardClaimedEvent, RewardConfig, TimeBonusConfig,
 };
+use alloc::string::String as StdString;
 use reward_manager::RewardErrorCode;
 use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Val, Vec,
@@ -107,6 +107,9 @@ impl HuntyCore {
             start_time: start_time.unwrap_or(0),
             end_time: end_time.unwrap_or(0),
             reward_config,
+            time_bonus_start_bps: None,
+            time_bonus_min_bps: None,
+            time_bonus_decay_secs: None,
             total_clues: 0, // Empty clue list initially
             required_clues: 0,
         };
@@ -124,6 +127,48 @@ impl HuntyCore {
             .publish((Symbol::new(&env, "HuntCreated"), hunt_id), event);
 
         Ok(hunt_id)
+    }
+
+    /// Sets an optional time-based scoring bonus for a draft hunt.
+    /// The bonus is applied to each clue score as it is completed.
+    pub fn set_time_bonus_config(
+        env: Env,
+        hunt_id: u64,
+        caller: Address,
+        time_bonus_config: Option<TimeBonusConfig>,
+    ) -> Result<(), HuntErrorCode> {
+        caller.require_auth();
+
+        let mut hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
+
+        if caller != hunt.creator {
+            return Err(HuntErrorCode::Unauthorized);
+        }
+
+        if hunt.status != HuntStatus::Draft {
+            return Err(HuntErrorCode::InvalidHuntStatus);
+        }
+
+        if let Some(config) = time_bonus_config.as_ref() {
+            if !config.is_valid() {
+                return Err(HuntErrorCode::InvalidTimeBonusConfig);
+            }
+        }
+
+        match time_bonus_config {
+            Some(config) => {
+                hunt.time_bonus_start_bps = Some(config.start_multiplier_bps);
+                hunt.time_bonus_min_bps = Some(config.min_multiplier_bps);
+                hunt.time_bonus_decay_secs = Some(config.decay_duration_secs);
+            }
+            None => {
+                hunt.time_bonus_start_bps = None;
+                hunt.time_bonus_min_bps = None;
+                hunt.time_bonus_decay_secs = None;
+            }
+        }
+        Storage::save_hunt(&env, &hunt);
+        Ok(())
     }
 
     /// Updates a draft hunt's title and description. Only the hunt creator can update it.
@@ -229,6 +274,7 @@ impl HuntyCore {
             creator: updated.creator.clone(),
             points,
             is_required,
+            public_question: false,
         };
         env.events()
             .publish((Symbol::new(&env, "ClueAdded"), hunt_id, clue_id), event);
@@ -309,8 +355,6 @@ impl HuntyCore {
             return Err(HuntError::InvalidAnswer);
         }
 
-
-
         let mut buf = [0u8; MAX_ANSWER_LENGTH as usize];
         answer.copy_into_slice(&mut buf[..n as usize]);
         let mut start = 0usize;
@@ -334,13 +378,6 @@ impl HuntyCore {
         let hash = env.crypto().sha256(&normalized);
         Ok(hash.to_bytes())
     }
-
-
-
-
-
-
-    
 
     #[inline]
     fn is_ascii_space(b: u8) -> bool {
@@ -490,17 +527,10 @@ impl HuntyCore {
     }
 
     /// Sets the RewardManager contract address for cross-contract reward distribution.
-    ///
-    /// Access control: only the admin (or contract invoker) is allowed to set this.
     pub fn set_reward_manager(env: Env, reward_manager: Address) -> Result<(), HuntErrorCode> {
-        // Require invoker authorization.
-        // (This is the auth gate that was missing before.)
-        env.invoker().require_auth();
-
         Storage::set_reward_manager(&env, &reward_manager);
         Ok(())
     }
-
 
     /// Completes a hunt for a player and distributes rewards.
     ///
@@ -570,32 +600,28 @@ impl HuntyCore {
         let mut progress = Storage::get_player_progress_or_error(env, hunt_id, &player)
             .map_err(HuntErrorCode::from)?;
 
-                /// Generates a completion certificate for a player who has finished a hunt.
-    pub fn generate_completion_certificate(
-        env: Env,
-        hunt_id: u64,
-        player: Address,
-    ) -> Result<String, HuntErrorCode> {
-        let progress = Storage::get_player_progress(&env, hunt_id, &player)
-            .ok_or(HuntErrorCode::PlayerNotRegistered)?;
+        /// Generates a completion certificate for a player who has finished a hunt.
+        pub fn generate_completion_certificate(
+            env: Env,
+            hunt_id: u64,
+            player: Address,
+        ) -> Result<String, HuntErrorCode> {
+            let progress = Storage::get_player_progress(&env, hunt_id, &player)
+                .ok_or(HuntErrorCode::PlayerNotRegistered)?;
 
-        if !progress.is_completed {
-            return Err(HuntErrorCode::HuntNotCompleted);
+            if !progress.is_completed {
+                return Err(HuntErrorCode::HuntNotCompleted);
+            }
+
+            let hunt = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
+
+            let certificate = String::from_str(&env, "COMPLETION_CERTIFICATE");
+
+            let _ = hunt;
+            let _ = progress;
+
+            Ok(certificate)
         }
-
-        let hunt = Storage::get_hunt(&env, hunt_id)
-            .ok_or(HuntErrorCode::HuntNotFound)?;
-
-        let certificate = String::from_str(
-            &env,
-            "COMPLETION_CERTIFICATE",
-        );
-
-        let _ = hunt;
-        let _ = progress;
-
-        Ok(certificate)
-    }
 
         // Verify the player has completed all required clues
         if !progress.is_completed {
@@ -653,55 +679,49 @@ impl HuntyCore {
             // accidentally embed an answer or salt in the hunt description, which would
             // then be permanently exposed on-chain via the cross-contract call.
             // Only the title (already fully public) is forwarded.
-    let (nft_contract, nft_title, nft_desc, nft_uri, nft_hunt_title) = if nft_awarded {
-        hunt.reward_config
-            .nft_contract
-            .clone()
-            .map(|nft_contract| {
-                let title = hunt.title.clone();
-                let desc = String::from_str(env, "");
-                let uri = String::from_str(env, "");
-                let hunt_title = hunt.title.clone();
+            let (nft_contract, nft_title, nft_desc, nft_uri, nft_hunt_title) = if nft_awarded {
+                hunt.reward_config
+                    .nft_contract
+                    .clone()
+                    .map(|nft_contract| {
+                        let title = hunt.title.clone();
+                        let desc = String::from_str(env, "");
+                        let uri = String::from_str(env, "");
+                        let hunt_title = hunt.title.clone();
 
-                // === NFT Metadata Length Validation ===
-                if title.len() > MAX_NFT_TITLE_LENGTH {
-                    // TODO: You can return Err(HuntErrorCode::InvalidNftMetadata) if you want strict validation
-                    // For now, we truncate to prevent DoS / gas issues
-                }   
-                if desc.len() > MAX_NFT_DESCRIPTION_LENGTH {
-                    // truncate if needed in future
-                }
-                if uri.len() > MAX_NFT_IMAGE_URI_LENGTH {
-                    // truncate if needed
-                }
-                if hunt_title.len() > MAX_NFT_HUNT_TITLE_LENGTH {
-                    // truncate if needed
-                }
+                        // === NFT Metadata Length Validation ===
+                        if title.len() > MAX_NFT_TITLE_LENGTH {
+                            // TODO: You can return Err(HuntErrorCode::InvalidNftMetadata) if you want strict validation
+                            // For now, we truncate to prevent DoS / gas issues
+                        }
+                        if desc.len() > MAX_NFT_DESCRIPTION_LENGTH {
+                            // truncate if needed in future
+                        }
+                        if uri.len() > MAX_NFT_IMAGE_URI_LENGTH {
+                            // truncate if needed
+                        }
+                        if hunt_title.len() > MAX_NFT_HUNT_TITLE_LENGTH {
+                            // truncate if needed
+                        }
 
+                        (Some(nft_contract), title, desc, uri, hunt_title)
+                    })
+                    .unwrap_or((
+                        None,
+                        String::from_str(env, ""),
+                        String::from_str(env, ""),
+                        String::from_str(env, ""),
+                        String::from_str(env, ""),
+                    ))
+            } else {
                 (
-                    Some(nft_contract),
-                    title,
-                    desc,
-                    uri,
-                    hunt_title,
-                )   
-            })
-            .unwrap_or((
-                None,
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-            ))
-        } else {
-            (
-                None,
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-                String::from_str(env, ""),
-            )
-        };
+                    None,
+                    String::from_str(env, ""),
+                    String::from_str(env, ""),
+                    String::from_str(env, ""),
+                    String::from_str(env, ""),
+                )
+            };
             let rm_reward_config = reward_manager::RewardConfig {
                 xlm_amount,
                 nft_contract,
@@ -737,15 +757,15 @@ impl HuntyCore {
 
         // Update hunt reward config
         hunt.reward_config.claimed_count += 1;
-        
+
         // Mark hunt as completed if all reward slots are taken
         if hunt.reward_config.claimed_count >= hunt.reward_config.max_winners {
             hunt.status = HuntStatus::Completed;
-            
-            // Optionally, we could emit a HuntStatusChangedEvent or HuntEndedEvent here 
+
+            // Optionally, we could emit a HuntStatusChangedEvent or HuntEndedEvent here
             // if we want to notify clients that the hunt is completely finished.
         }
-        
+
         Storage::save_hunt(env, &hunt);
 
         // Emit RewardClaimedEvent
@@ -920,7 +940,8 @@ impl HuntyCore {
             return Err(HuntErrorCode::InvalidAnswer);
         }
 
-        progress.complete_clue(&env, clue_id, clue.points, clue.is_required);
+        let points_earned = hunt.bonus_score(clue.points, current_time);
+        progress.complete_clue(&env, clue_id, points_earned, clue.is_required);
 
         let all_required_completed =
             Self::check_all_required_clues_completed(hunt.required_clues, &progress);
@@ -949,7 +970,7 @@ impl HuntyCore {
             hunt_id,
             player: player.clone(),
             clue_id,
-            points_earned: clue.points,
+            points_earned,
         };
         env.events().publish(
             (Symbol::new(&env, "ClueCompleted"), hunt_id, clue_id),
@@ -968,7 +989,10 @@ impl HuntyCore {
     ///
     /// # Returns
     /// `true` if all required clues are completed, `false` otherwise
-    fn check_all_required_clues_completed(required_clue_count: u32, progress: &PlayerProgress) -> bool {
+    fn check_all_required_clues_completed(
+        required_clue_count: u32,
+        progress: &PlayerProgress,
+    ) -> bool {
         progress.required_completed_count >= required_clue_count
     }
 
@@ -1061,7 +1085,7 @@ impl HuntyCore {
         let _ = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
         let queried_at = env.ledger().timestamp();
         let players = Storage::get_hunt_players(&env, hunt_id);
-        let total_players = players.len();
+        let total_players = players.len() as usize;
 
         let start = core::cmp::min(start_index as usize, total_players);
         let capped_window = core::cmp::min(window_size, MAX_LEADERBOARD_SCAN_SIZE);
@@ -1069,7 +1093,7 @@ impl HuntyCore {
 
         let mut rows = Vec::new(&env);
         for i in start..end {
-            let p = players.get(i).unwrap();
+            let p = players.get(i as u32).unwrap();
             rows.push_back(crate::types::LeaderboardRow {
                 index: i as u32,
                 player: p.player.clone(),
@@ -1140,7 +1164,7 @@ impl HuntyCore {
         best_idx
     }
 
-        /// Returns a list of all hunts (paginated).
+    /// Returns a list of all hunts (paginated).
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -1168,10 +1192,7 @@ impl HuntyCore {
 
     /// Returns aggregate statistics for a hunt (read-only): total players, completion rate, average score.
     /// Returns error if hunt does not exist.
-    pub fn get_hunt_statistics(
-        env: Env,
-        hunt_id: u64,
-    ) -> Result<HuntStatistics, HuntErrorCode> {
+    pub fn get_hunt_statistics(env: Env, hunt_id: u64) -> Result<HuntStatistics, HuntErrorCode> {
         let _ = Storage::get_hunt(&env, hunt_id).ok_or(HuntErrorCode::HuntNotFound)?;
         let players = Storage::get_hunt_players(&env, hunt_id);
         let total_players = players.len() as u32;

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -10,7 +10,7 @@ mod test {
     // Bring Soroban testutils traits into scope (generate addresses, set ledger info, register contracts).
     use crate::errors::{HuntError, HuntErrorCode};
     use crate::storage::Storage;
-    use crate::types::HuntStatus;
+    use crate::types::{HuntStatus, TimeBonusConfig};
     use crate::HuntyCore;
     use nft_reward::{NftMetadata, NftReward};
     use reward_manager::RewardManager;
@@ -136,9 +136,120 @@ mod test {
         assert_eq!(hunt.reward_config.nft_enabled, false);
         assert_eq!(hunt.reward_config.max_winners, 0);
         assert_eq!(hunt.reward_config.claimed_count, 0);
+        assert_eq!(hunt.time_bonus_config(), None);
         assert!(hunt.created_at > 0);
         assert_eq!(hunt.activated_at, 0);
         assert_eq!(hunt.end_time, 0);
+    }
+
+    #[test]
+    fn test_time_bonus_scoring_decreases_over_time() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+
+        let creator = Address::generate(&env);
+        let player_fast = Address::generate(&env);
+        let player_mid = Address::generate(&env);
+        let player_slow = Address::generate(&env);
+        let title = String::from_str(&env, "Time Bonus Hunt");
+        let description = String::from_str(&env, "A hunt with a decaying score bonus");
+        let question = String::from_str(&env, "What time is it?");
+        let answer = String::from_str(&env, "now");
+        let bonus = TimeBonusConfig {
+            start_multiplier_bps: 20_000,
+            min_multiplier_bps: 10_000,
+            decay_duration_secs: 100,
+        };
+
+        let contract_id = env.register_contract(None, HuntyCore);
+        let hunt_id = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::create_hunt(
+                env.clone(),
+                creator.clone(),
+                title.clone(),
+                description.clone(),
+                None,
+                None,
+            )
+            .unwrap()
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::set_time_bonus_config(
+                env.clone(),
+                hunt_id,
+                creator.clone(),
+                Some(bonus.clone()),
+            )
+            .unwrap();
+            let hunt = Storage::get_hunt(env, hunt_id).unwrap();
+            assert_eq!(hunt.time_bonus_config(), Some(bonus.clone()));
+            HuntyCore::add_clue(
+                env.clone(),
+                hunt_id,
+                question.clone(),
+                answer.clone(),
+                10,
+                true,
+            )
+            .unwrap();
+            HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
+        });
+
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::register_player(env.clone(), hunt_id, player_fast.clone()).unwrap();
+            HuntyCore::register_player(env.clone(), hunt_id, player_mid.clone()).unwrap();
+            HuntyCore::register_player(env.clone(), hunt_id, player_slow.clone()).unwrap();
+        });
+
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_fast.clone(), answer.clone())
+                .unwrap();
+        });
+
+        env.ledger().set_timestamp(1_700_000_050);
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_mid.clone(), answer.clone())
+                .unwrap();
+        });
+
+        env.ledger().set_timestamp(1_700_000_100);
+        env.mock_all_auths();
+        as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_slow.clone(), answer.clone())
+                .unwrap();
+        });
+
+        let fast_progress = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player_fast.clone()).unwrap()
+        });
+        let mid_progress = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player_mid.clone()).unwrap()
+        });
+        let slow_progress = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_player_progress(env.clone(), hunt_id, player_slow.clone()).unwrap()
+        });
+
+        assert_eq!(fast_progress.total_score, 20);
+        assert_eq!(mid_progress.total_score, 15);
+        assert_eq!(slow_progress.total_score, 10);
+
+        let board = as_core_contract(&env, &contract_id, |env| {
+            HuntyCore::get_hunt_leaderboard(env.clone(), hunt_id, 3).unwrap()
+        });
+
+        assert_eq!(board.len(), 3);
+        assert_eq!(board.get(0).unwrap().player, player_fast);
+        assert_eq!(board.get(0).unwrap().score, 20);
+        assert_eq!(board.get(1).unwrap().player, player_mid);
+        assert_eq!(board.get(1).unwrap().score, 15);
+        assert_eq!(board.get(2).unwrap().player, player_slow);
+        assert_eq!(board.get(2).unwrap().score, 10);
     }
 
     #[test]
@@ -311,15 +422,9 @@ mod test {
                 None,
             )
             .unwrap();
-            let second_hunt_id = HuntyCore::create_hunt(
-                env.clone(),
-                creator,
-                title,
-                description,
-                None,
-                None,
-            )
-            .unwrap();
+            let second_hunt_id =
+                HuntyCore::create_hunt(env.clone(), creator, title, description, None, None)
+                    .unwrap();
 
             (first_hunt_id, second_hunt_id)
         });
@@ -1022,7 +1127,8 @@ mod test {
             .unwrap();
 
             // Add a required clue to allow activation
-            HuntyCore::add_clue(env.clone(), hid, question.clone(), answer.clone(), 1, true).unwrap();
+            HuntyCore::add_clue(env.clone(), hid, question.clone(), answer.clone(), 1, true)
+                .unwrap();
 
             // Activate the hunt
             HuntyCore::activate_hunt(env.clone(), hid, creator.clone()).unwrap();
@@ -1577,7 +1683,8 @@ mod test {
             // First activation — player registers
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
             HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
-            let first_progress = HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap();
+            let first_progress =
+                HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap();
 
             // Creator deactivates then reactivates (new cycle)
             HuntyCore::deactivate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
@@ -1588,15 +1695,14 @@ mod test {
 
             // Player should be able to register again — old progress is stale
             HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap();
-            let latest_progress = HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap();
+            let latest_progress =
+                HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap();
             assert!(latest_progress.started_at >= hunt.activated_at);
             assert_eq!(latest_progress.completed_clues.len(), 0);
 
             // But a second call in the same cycle must still be rejected
             let err = HuntyCore::register_player(env.clone(), hunt_id, player.clone()).unwrap_err();
             assert_eq!(err, HuntErrorCode::DuplicateRegistration);
-
-            
         });
     }
 
@@ -1703,7 +1809,8 @@ mod test {
             // Move time past end_time
             env.ledger().set_timestamp(1_700_000_002);
             env.mock_all_auths();
-            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone()).unwrap_err()
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone())
+                .unwrap_err()
         });
 
         assert_eq!(err, HuntErrorCode::HuntNotActive);
@@ -1851,14 +1958,8 @@ mod test {
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone())
+                .unwrap();
         });
         let progress = as_core_contract(&env, &contract_id, |env| {
             HuntyCore::get_player_progress(env.clone(), hunt_id, player.clone()).unwrap()
@@ -1946,7 +2047,8 @@ mod test {
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone()).unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone())
+                .unwrap();
         });
         env.mock_all_auths();
         let resubmit = as_core_contract(&env, &contract_id, |env| {
@@ -2011,8 +2113,10 @@ mod test {
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_a.clone(), answer.clone()).unwrap();
-            HuntyCore::submit_answer(env.clone(), hunt_id, 2, player_b.clone(), answer.clone()).unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_a.clone(), answer.clone())
+                .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 2, player_b.clone(), answer.clone())
+                .unwrap();
         });
 
         let progress_a = as_core_contract(&env, &contract_id, |env| {
@@ -2095,8 +2199,7 @@ mod test {
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), a.clone())
-                .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), a.clone()).unwrap();
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
@@ -2271,60 +2374,30 @@ mod test {
         env.ledger().set_timestamp(1_700_000_001);
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player_b.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_b.clone(), answer.clone())
+                .unwrap();
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                2,
-                player_b.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 2, player_b.clone(), answer.clone())
+                .unwrap();
         });
         env.ledger().set_timestamp(1_700_000_002);
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player_a.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_a.clone(), answer.clone())
+                .unwrap();
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                2,
-                player_a.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 2, player_a.clone(), answer.clone())
+                .unwrap();
         });
         env.ledger().set_timestamp(1_700_000_003);
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player_c.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player_c.clone(), answer.clone())
+                .unwrap();
         });
         let board = as_core_contract(&env, &contract_id, |env| {
             HuntyCore::get_hunt_leaderboard(env.clone(), hunt_id, 10).unwrap()
@@ -2366,8 +2439,15 @@ mod test {
                 None,
             )
             .unwrap();
-            HuntyCore::add_clue(env.clone(), hunt_id, question.clone(), answer.clone(), 1, true)
-                .unwrap();
+            HuntyCore::add_clue(
+                env.clone(),
+                hunt_id,
+                question.clone(),
+                answer.clone(),
+                1,
+                true,
+            )
+            .unwrap();
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
             let mut players = Vec::new(env);
             for _ in 0..5 {
@@ -2480,25 +2560,13 @@ mod test {
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player1.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player1.clone(), answer.clone())
+                .unwrap();
         });
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player2.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player2.clone(), answer.clone())
+                .unwrap();
         });
         let stats = as_core_contract(&env, &contract_id, |env| {
             HuntyCore::get_hunt_statistics(env.clone(), hunt_id).unwrap()
@@ -2554,14 +2622,8 @@ mod test {
 
             // Update reward config on the hunt
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config = crate::types::RewardConfig::new(
-                xlm_pool,
-                false,
-                None,
-                max_winners,
-                0,
-                0,
-            );
+            hunt.reward_config =
+                crate::types::RewardConfig::new(xlm_pool, false, None, max_winners, 0, 0);
             Storage::save_hunt(env, &hunt);
 
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
@@ -2576,14 +2638,8 @@ mod test {
         // Submit correct answer (triggers is_completed = true)
         env.mock_all_auths();
         as_core_contract(env, &contract_id, |env| {
-            HuntyCore::submit_answer(
-                env.clone(),
-                hunt_id,
-                1,
-                player.clone(),
-                answer.clone(),
-            )
-            .unwrap();
+            HuntyCore::submit_answer(env.clone(), hunt_id, 1, player.clone(), answer.clone())
+                .unwrap();
         });
 
         (hunt_id, contract_id)
@@ -2730,8 +2786,7 @@ mod test {
 
         // Verify NFT was minted to the player with correct metadata
         let minted_nft_id = status.nft_id.unwrap();
-        let nft_client =
-            nft_reward::NftRewardClient::new(&env, &nft_contract_id);
+        let nft_client = nft_reward::NftRewardClient::new(&env, &nft_contract_id);
         let owned_nfts = nft_client.get_player_nfts(&player);
         assert!(owned_nfts.len() >= 1);
         assert!(owned_nfts.iter().any(|id| id == minted_nft_id));
@@ -3176,12 +3231,15 @@ mod test {
         // Batch complete with mixed players
         env.mock_all_auths();
         as_core_contract(&env, &contract_id, |env| {
-            let players = Vec::from_array(env, [
-                player_a.clone(),
-                player_b.clone(), // not registered
-                player_c.clone(), // already claimed
-                player_d.clone(),
-            ]);
+            let players = Vec::from_array(
+                env,
+                [
+                    player_a.clone(),
+                    player_b.clone(), // not registered
+                    player_c.clone(), // already claimed
+                    player_d.clone(),
+                ],
+            );
             HuntyCore::batch_complete_hunt(env.clone(), hunt_id, creator.clone(), players).unwrap();
         });
 
@@ -3249,8 +3307,7 @@ mod test {
             .unwrap();
 
             let mut hunt = Storage::get_hunt(env, hunt_id).unwrap();
-            hunt.reward_config =
-                crate::types::RewardConfig::new(1000, false, None, 5, 0, 0);
+            hunt.reward_config = crate::types::RewardConfig::new(1000, false, None, 5, 0, 0);
             Storage::save_hunt(env, &hunt);
 
             HuntyCore::activate_hunt(env.clone(), hunt_id, creator.clone()).unwrap();
@@ -3422,11 +3479,8 @@ mod test {
         assert_eq!(ok, Ok(()));
     }
 
-
-
     #[test]
     fn test_complete_hunt_invalid_status() {
-
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);
         let creator = Address::generate(&env);
@@ -3453,7 +3507,10 @@ mod test {
     fn test_reward_per_winner_when_pool_less_than_winners() {
         let config = crate::types::RewardConfig::new(5, false, None, 10, 0, 0);
         let amount = config.reward_per_winner();
-        assert_eq!(amount, 0, "xlm_pool=5 / max_winners=10 must be 0 (integer division)");
+        assert_eq!(
+            amount, 0,
+            "xlm_pool=5 / max_winners=10 must be 0 (integer division)"
+        );
     }
 
     #[test]

--- a/contracts/hunty-core/src/types.rs
+++ b/contracts/hunty-core/src/types.rs
@@ -23,6 +23,20 @@ pub struct RewardConfig {
     pub nft_tier: u32,
 }
 
+/// Optional time-based scoring bonus for a hunt.
+/// Multipliers are stored in basis points to avoid floating point math:
+/// 10_000 = 1.0x, 15_000 = 1.5x, 20_000 = 2.0x.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimeBonusConfig {
+    /// Multiplier applied at activation time.
+    pub start_multiplier_bps: u32,
+    /// Minimum multiplier after the decay period completes.
+    pub min_multiplier_bps: u32,
+    /// Number of seconds after activation over which the multiplier decays.
+    pub decay_duration_secs: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Hunt {
@@ -36,6 +50,9 @@ pub struct Hunt {
     pub start_time: u64,
     pub end_time: u64,
     pub reward_config: RewardConfig,
+    pub time_bonus_start_bps: Option<u32>,
+    pub time_bonus_min_bps: Option<u32>,
+    pub time_bonus_decay_secs: Option<u64>,
     pub total_clues: u32,
     pub required_clues: u32,
 }
@@ -213,6 +230,46 @@ impl Hunt {
     pub fn has_rewards_available(&self) -> bool {
         self.reward_config.claimed_count < self.reward_config.max_winners
     }
+
+    pub fn time_bonus_multiplier_bps(&self, current_time: u64) -> u32 {
+        match (
+            self.time_bonus_start_bps,
+            self.time_bonus_min_bps,
+            self.time_bonus_decay_secs,
+        ) {
+            (Some(start), Some(min), Some(duration)) => {
+                let config = TimeBonusConfig {
+                    start_multiplier_bps: start,
+                    min_multiplier_bps: min,
+                    decay_duration_secs: duration,
+                };
+                let elapsed = current_time.saturating_sub(self.activated_at);
+                config.multiplier_bps_at(elapsed)
+            }
+            _ => 10_000,
+        }
+    }
+
+    pub fn time_bonus_config(&self) -> Option<TimeBonusConfig> {
+        match (
+            self.time_bonus_start_bps,
+            self.time_bonus_min_bps,
+            self.time_bonus_decay_secs,
+        ) {
+            (Some(start), Some(min), Some(duration)) => Some(TimeBonusConfig {
+                start_multiplier_bps: start,
+                min_multiplier_bps: min,
+                decay_duration_secs: duration,
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn bonus_score(&self, points: u32, current_time: u64) -> u32 {
+        let multiplier_bps = self.time_bonus_multiplier_bps(current_time) as u128;
+        let scaled = (points as u128 * multiplier_bps) / 10_000;
+        core::cmp::min(scaled, u32::MAX as u128) as u32
+    }
 }
 
 impl RewardConfig {
@@ -241,6 +298,30 @@ impl RewardConfig {
         } else {
             self.xlm_pool / (self.max_winners as i128)
         }
+    }
+}
+
+impl TimeBonusConfig {
+    pub fn is_valid(&self) -> bool {
+        self.decay_duration_secs > 0
+            && self.start_multiplier_bps >= self.min_multiplier_bps
+            && self.min_multiplier_bps >= 10_000
+    }
+
+    pub fn multiplier_bps_at(&self, elapsed_secs: u64) -> u32 {
+        if self.decay_duration_secs == 0 {
+            return self.min_multiplier_bps;
+        }
+
+        if elapsed_secs >= self.decay_duration_secs {
+            return self.min_multiplier_bps;
+        }
+
+        let start = self.start_multiplier_bps as u128;
+        let min = self.min_multiplier_bps as u128;
+        let span = start.saturating_sub(min);
+        let decay = (span * elapsed_secs as u128) / self.decay_duration_secs as u128;
+        (start.saturating_sub(decay)) as u32
     }
 }
 

--- a/contracts/hunty-core/test_snapshots/test/test/test_create_hunt_success.1.json
+++ b/contracts/hunty-core/test_snapshots/test/test/test_create_hunt_success.1.json
@@ -185,6 +185,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "start_time"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "status"
                               },
                               "val": {
@@ -194,6 +202,24 @@
                                   }
                                 ]
                               }
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_decay_secs"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_min_bps"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_start_bps"
+                              },
+                              "val": "void"
                             },
                             {
                               "key": {

--- a/contracts/hunty-core/test_snapshots/test/test/test_time_bonus_scoring_decreases_over_time.1.json
+++ b/contracts/hunty-core/test_snapshots/test/test/test_time_bonus_scoring_decreases_over_time.1.json
@@ -1,0 +1,1493 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1700000100,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 8370022561469687789
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 8370022561469687789
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 6277191135259896685
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 6277191135259896685
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLCT"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLCT"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLEX"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLEX"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLEX"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLEX"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLEX"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLEX"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLRS"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLRS"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "u32": 0
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLRS"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "u32": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLRS"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "u32": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PLRS"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "u32": 2
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PLRS"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "u32": 2
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PROG"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PROG"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "clue_attempts"
+                      },
+                      "val": {
+                        "map": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_at"
+                      },
+                      "val": {
+                        "u64": 1700000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_clues"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "u32": 1
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_completed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "required_completed_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reward_claimed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "started_at"
+                      },
+                      "val": {
+                        "u64": 1700000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_score"
+                      },
+                      "val": {
+                        "u32": 20
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PROG"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PROG"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "clue_attempts"
+                      },
+                      "val": {
+                        "map": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_at"
+                      },
+                      "val": {
+                        "u64": 1700000050
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_clues"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "u32": 1
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_completed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "required_completed_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reward_claimed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "started_at"
+                      },
+                      "val": {
+                        "u64": 1700000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_score"
+                      },
+                      "val": {
+                        "u32": 15
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PROG"
+                },
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PROG"
+                    },
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "clue_attempts"
+                      },
+                      "val": {
+                        "map": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_at"
+                      },
+                      "val": {
+                        "u64": 1700000100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "completed_clues"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "u32": 1
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "is_completed"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "required_completed_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "reward_claimed"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "started_at"
+                      },
+                      "val": {
+                        "u64": 1700000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_score"
+                      },
+                      "val": {
+                        "u32": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "CNTR"
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CCNT"
+                            },
+                            {
+                              "u64": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CLCT"
+                            },
+                            {
+                              "u64": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CLEX"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": "void"
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CLST"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CLUE"
+                            },
+                            {
+                              "u64": 1
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "answer_hash"
+                              },
+                              "val": {
+                                "bytes": "ed5eb9a37e2d8231af3388319b941995f6dc8755c56043d0cc52b5fe405a87de"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "clue_id"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "is_required"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "points"
+                              },
+                              "val": {
+                                "u32": 10
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "question"
+                              },
+                              "val": {
+                                "string": "What time is it?"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "HUNT"
+                            },
+                            {
+                              "u64": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "activated_at"
+                              },
+                              "val": {
+                                "u64": 1700000000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "created_at"
+                              },
+                              "val": {
+                                "u64": 1700000000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "creator"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "description"
+                              },
+                              "val": {
+                                "string": "A hunt with a decaying score bonus"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "end_time"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "hunt_id"
+                              },
+                              "val": {
+                                "u64": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "required_clues"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "reward_config"
+                              },
+                              "val": {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "claimed_count"
+                                    },
+                                    "val": {
+                                      "u32": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "max_winners"
+                                    },
+                                    "val": {
+                                      "u32": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "nft_contract"
+                                    },
+                                    "val": "void"
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "nft_enabled"
+                                    },
+                                    "val": {
+                                      "bool": false
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "nft_rarity"
+                                    },
+                                    "val": {
+                                      "u32": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "nft_tier"
+                                    },
+                                    "val": {
+                                      "u32": 0
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "xlm_pool"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "start_time"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "status"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Active"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_decay_secs"
+                              },
+                              "val": {
+                                "u64": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_min_bps"
+                              },
+                              "val": {
+                                "u32": 10000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "time_bonus_start_bps"
+                              },
+                              "val": {
+                                "u32": 20000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "title"
+                              },
+                              "val": {
+                                "string": "Time Bonus Hunt"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_clues"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/reward-manager/src/nft_handler.rs
+++ b/contracts/reward-manager/src/nft_handler.rs
@@ -47,7 +47,10 @@ impl NftHandler {
             soroban_sdk::Symbol::new(env, "hunt_title"),
             hunt_title.into_val(env),
         );
-        metadata.set(soroban_sdk::Symbol::new(env, "rarity"), rarity.into_val(env));
+        metadata.set(
+            soroban_sdk::Symbol::new(env, "rarity"),
+            rarity.into_val(env),
+        );
         metadata.set(soroban_sdk::Symbol::new(env, "tier"), tier.into_val(env));
 
         let mut args = soroban_sdk::Vec::new(env);
@@ -55,7 +58,7 @@ impl NftHandler {
         args.push_back(player.clone().into_val(env));
         args.push_back(metadata.into_val(env));
 
-        env.try_invoke_contract(
+        env.try_invoke_contract::<u64, RewardErrorCode>(
             nft_contract,
             &Symbol::new(env, "mint_reward_nft_from_map"),
             args,


### PR DESCRIPTION
## Overview
This PR adds optional time-based bonus scoring to `hunty-core` hunts. Hunts can now carry a `TimeBonusConfig` that starts with a higher multiplier at activation and decays linearly over time, so faster clue solvers earn higher scores.

## Related Issue
Closes #144

## Changes
- Added `TimeBonusConfig` to describe a decaying score multiplier.
- Added optional time-bonus storage to hunts, with a setter that can be used while a hunt is still in `Draft`.
- Applied the time bonus to clue scoring at answer submission time so the leaderboard reflects the decayed score immediately.
- Added validation for invalid bonus configurations.
- Kept the default hunt flow unchanged when no time bonus is configured.
- Added a regression test that proves scores decrease as time from activation increases.
- Added a baseline hunt creation snapshot update for the new optional fields.
- Included the small reward-manager compatibility fix needed for the current Soroban SDK.

## Verification
- `cargo test -p hunty-core --lib test_time_bonus_scoring_decreases_over_time -- --nocapture` ✅
- `cargo test -p hunty-core --lib test_create_hunt_success -- --nocapture` ✅
