### PR TITLE
Add reward pool validation to activate_hunt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings

--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -373,6 +373,33 @@ impl HuntyCore {
             return Err(HuntErrorCode::NoRequiredClues);
         }
 
+        // Check rewards are configured
+        if hunt.reward_config.max_winners == 0 {
+            return Err(HuntErrorCode::NoRewardsConfigured);
+        }
+
+        // Check reward pool has sufficient balance if reward manager is configured
+        if let Some(reward_manager_addr) = Storage::get_reward_manager(&env) {
+            let mut balance_args: Vec<Val> = Vec::new(&env);
+            balance_args.push_back(hunt_id.into_val(&env));
+            let pool_balance = match env.try_invoke_contract::<i128, RewardErrorCode>(
+                &reward_manager_addr,
+                &Symbol::new(&env, "get_pool_balance"),
+                balance_args,
+            ) {
+                Ok(Ok(balance)) => balance,
+                _ => return Err(HuntErrorCode::InsufficientRewardPool),
+            };
+
+            // Update the stored xlm_pool with the actual balance from reward manager
+            hunt.reward_config.xlm_pool = pool_balance;
+
+            // Check if pool has sufficient balance for the configured rewards
+            if !hunt.has_rewards_available() {
+                return Err(HuntErrorCode::InsufficientRewardPool);
+            }
+        }
+
         let current_time = env.ledger().timestamp();
         // Enforce configured start_time: cannot activate before start_time
         if hunt.start_time != 0 && current_time < hunt.start_time {


### PR DESCRIPTION
This PR addresses issue by adding reward pool validation to the activate_hunt function. Previously, hunts could be activated without proper reward configuration, leading to NoRewardsConfigured or InsufficientRewardPool errors when players tried to complete them.

Changes:

Added validation to check if rewards are configured (max_winners > 0) before hunt activation
Added validation to check if the reward pool has sufficient balance when a reward manager is configured
Updated the stored xlm_pool with the actual balance from the reward manager during activation
Returns NoRewardsConfigured error if rewards are not configured
Returns InsufficientRewardPool error if the pool balance is insufficient
This ensures hunts cannot go live without proper reward funding, preventing player frustration and improving the user experience.

Closes #125 