### PR TITLE
fix: normalize answers using Unicode trim/lowercase and add whitespac…

### DIFF
--- a/contracts/hunty-core/src/lib.rs
+++ b/contracts/hunty-core/src/lib.rs
@@ -313,23 +313,12 @@ impl HuntyCore {
 
         let mut buf = [0u8; MAX_ANSWER_LENGTH as usize];
         answer.copy_into_slice(&mut buf[..n as usize]);
-        let mut start = 0usize;
-        let mut end = n as usize;
-        while start < end && Self::is_ascii_space(buf[start]) {
-            start += 1;
-        }
-        while end > start && Self::is_ascii_space(buf[end - 1]) {
-            end -= 1;
-        }
-        if start >= end {
+        let text = core::str::from_utf8(&buf[..n as usize]).map_err(|_| HuntError::InvalidAnswer)?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
             return Err(HuntError::InvalidAnswer);
         }
-        let slice = &buf[start..end];
-        let text = core::str::from_utf8(slice).map_err(|_| HuntError::InvalidAnswer)?;
-        let normalized = text.to_lowercase();
-        if normalized.is_empty() {
-            return Err(HuntError::InvalidAnswer);
-        }
+        let normalized = trimmed.to_lowercase();
         let normalized = Bytes::from_slice(env, normalized.as_bytes());
         let hash = env.crypto().sha256(&normalized);
         Ok(hash.to_bytes())
@@ -341,11 +330,6 @@ impl HuntyCore {
 
 
     
-
-    #[inline]
-    fn is_ascii_space(b: u8) -> bool {
-        b == 0x20 || b == 0x09 || b == 0x0a || b == 0x0d
-    }
 
     #[inline]
     fn validate_rarity(v: u32) -> bool {
@@ -570,33 +554,6 @@ impl HuntyCore {
         let mut progress = Storage::get_player_progress_or_error(env, hunt_id, &player)
             .map_err(HuntErrorCode::from)?;
 
-                /// Generates a completion certificate for a player who has finished a hunt.
-    pub fn generate_completion_certificate(
-        env: Env,
-        hunt_id: u64,
-        player: Address,
-    ) -> Result<String, HuntErrorCode> {
-        let progress = Storage::get_player_progress(&env, hunt_id, &player)
-            .ok_or(HuntErrorCode::PlayerNotRegistered)?;
-
-        if !progress.is_completed {
-            return Err(HuntErrorCode::HuntNotCompleted);
-        }
-
-        let hunt = Storage::get_hunt(&env, hunt_id)
-            .ok_or(HuntErrorCode::HuntNotFound)?;
-
-        let certificate = String::from_str(
-            &env,
-            "COMPLETION_CERTIFICATE",
-        );
-
-        let _ = hunt;
-        let _ = progress;
-
-        Ok(certificate)
-    }
-
         // Verify the player has completed all required clues
         if !progress.is_completed {
             return Err(HuntErrorCode::HuntNotCompleted);
@@ -759,6 +716,30 @@ impl HuntyCore {
             .publish((Symbol::new(env, "RewardClaimed"), hunt_id), event);
 
         Ok(())
+    }
+
+    /// Generates a completion certificate for a player who has finished a hunt.
+    pub fn generate_completion_certificate(
+        env: Env,
+        hunt_id: u64,
+        player: Address,
+    ) -> Result<String, HuntErrorCode> {
+        let progress = Storage::get_player_progress(&env, hunt_id, &player)
+            .ok_or(HuntErrorCode::PlayerNotRegistered)?;
+
+        if !progress.is_completed {
+            return Err(HuntErrorCode::HuntNotCompleted);
+        }
+
+        let hunt = Storage::get_hunt(&env, hunt_id)
+            .ok_or(HuntErrorCode::HuntNotFound)?;
+
+        let certificate = String::from_str(&env, "COMPLETION_CERTIFICATE");
+
+        let _ = hunt;
+        let _ = progress;
+
+        Ok(certificate)
     }
 
     /// Registers a player for an active hunt. The caller must pass their address and authorize;

--- a/contracts/hunty-core/src/test.rs
+++ b/contracts/hunty-core/src/test.rs
@@ -607,6 +607,53 @@ mod test {
     }
 
     #[test]
+    fn test_add_clue_whitespace_answer_normalization_and_hashing() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_000);
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let title = String::from_str(&env, "Hunt");
+        let description = String::from_str(&env, "Desc");
+        let question = String::from_str(&env, "Whitespace answer?");
+        let answer1 = String::from_str(&env, "\t\n answer \r\n");
+        let answer2 = String::from_str(&env, "answer");
+
+        let (hash1, hash2) = with_core_contract(&env, |env, _cid| {
+            let hid = HuntyCore::create_hunt(
+                env.clone(),
+                creator,
+                title,
+                description.clone(),
+                None,
+                None,
+            )
+            .unwrap();
+            let cid = HuntyCore::add_clue(env.clone(), hid, question.clone(), answer1, 5, false)
+                .unwrap();
+            let c = Storage::get_clue(env, hid, cid).unwrap();
+            let h1 = c.answer_hash;
+            let hid2 = HuntyCore::create_hunt(
+                env.clone(),
+                Address::generate(&env),
+                String::from_str(&env, "H2"),
+                description,
+                None,
+                None,
+            )
+            .unwrap();
+            let _cid2 = HuntyCore::add_clue(env.clone(), hid2, question, answer2, 5, false).unwrap();
+            let c2 = Storage::get_clue(env, hid2, _cid2).unwrap();
+            let h2 = c2.answer_hash;
+            (h1, h2)
+        });
+
+        assert_eq!(
+            hash1, hash2,
+            "normalized '\t\n answer \r\n' and 'answer' must hash the same"
+        );
+    }
+
+    #[test]
     fn test_add_clue_unicode_answer_normalization_and_hashing() {
         let env = Env::default();
         env.ledger().set_timestamp(1_700_000_000);


### PR DESCRIPTION
No function to update reward_config (xlm_pool, nft_enabled, max_winners) after creation
Repo Avatar
[Samuel1-ona/Hunty-contract](https://github.com/Samuel1-ona/Hunty-contract)
Feature: RewardConfig is set at hunt creation with zeros and there is no configure_rewards function. Creators cannot set up XLM rewards or NFTs after creation. Add configure_rewards(hunt_id, caller, xlm_pool, nft_enabled, nft_contract, max_winners) restricted to Draft status.

closes #100 